### PR TITLE
handle situations where two initdb start at the same time

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,6 +5,11 @@ Changes
 .. ----------
 .. -
 
+1.0.3 (unrelased)
+-----------------
+- fix: handle situations where two initdb start at the same time
+  ending up with an "already exists" error when creating the cached template
+
 1.0.2 (2018-05-29)
 ------------------
 - fix: initdb now stores attachments in database when cache is enabled,

--- a/tests/test_initdb.py
+++ b/tests/test_initdb.py
@@ -218,3 +218,11 @@ def test_create_cmd_nocache(dbcache):
                 "some attachments are not stored in filestore"
     finally:
         _dropdb(TEST_DBNAME_NEW)
+
+
+def test_dbcache_add_concurrency(pgdb, dbcache):
+    assert dbcache.size == 0
+    dbcache.add(pgdb, TEST_HASH1)
+    assert dbcache.size == 1
+    dbcache.add(pgdb, TEST_HASH1)
+    assert dbcache.size == 1


### PR DESCRIPTION
...ending up with an "already exists" error when creating
the cached template