### PR TITLE
initdb: include modules with active=True in hash computation

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -8,6 +8,8 @@ Changes
 1.0.5 (unreleased)
 ------------------
 - add click-odoo-makepot
+- in click-odoo-initdb, include active=True modules in hash computation
+  (because modules with active=True are auto installed by Odoo)
 
 1.0.4 (2018-06-02)
 ------------------

--- a/click_odoo_contrib/initdb.py
+++ b/click_odoo_contrib/initdb.py
@@ -102,7 +102,7 @@ def _walk(top, exclude_patterns=EXCLUDE_PATTERNS):
 def addons_hash(module_names, with_demo):
     h = hashlib.sha1()
     h.update('!demo={}!'.format(int(bool(with_demo))).encode('utf8'))
-    for module_name in sorted(expand_dependencies(module_names, True)):
+    for module_name in sorted(expand_dependencies(module_names, True, True)):
         module_path = odoo.modules.get_module_path(module_name)
         h.update(module_name.encode('utf8'))
         for filepath in _walk(module_path):

--- a/click_odoo_contrib/manifest.py
+++ b/click_odoo_contrib/manifest.py
@@ -49,7 +49,9 @@ def find_addons(addons_dir, installable_only=True):
         yield addon_name, addon_dir, manifest
 
 
-def expand_dependencies(module_names, include_auto_install=False):
+def expand_dependencies(module_names,
+                        include_auto_install=False,
+                        include_active=False):
     """ Return a set of module names with their transitive
     dependencies.  This method does not need an Odoo database,
     but requires the addons path to be initialized.
@@ -69,6 +71,12 @@ def expand_dependencies(module_names, include_auto_install=False):
     res = set()
     for module_name in module_names:
         add_deps(module_name)
+    if include_active:
+        for module_name in sorted(odoo.modules.module.get_modules()):
+            module_path = odoo.modules.get_module_path(module_name)
+            manifest = read_manifest(module_path)
+            if manifest.get('active'):
+                add_deps(module_name)
     if include_auto_install:
         auto_install_list = []
         for module_name in sorted(odoo.modules.module.get_modules()):


### PR DESCRIPTION
These are autoinstalled by Odoo.

@ThomasBinsfeld @Cedric-Pigeon 