### PR TITLE
[FIX] tox env typo

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,10 +15,10 @@ jobs:
   include:
     - stage: linting
       python: 3.6
-      env: TOXENV=pre_commit
+      env: TOXENV=pre-commit
     - stage: linting
       python: 3.6
-      env: TOXENV=check_readme
+      env: TOXENV=check-readme
     - stage: test
       python: 2.7
       env: ODOO="8.0"

--- a/tox.ini
+++ b/tox.ini
@@ -7,7 +7,7 @@
 envlist =
   py{35,36}-{11.0,12.0,master}
   py27-{8.0,9.0,10.0}
-  check_readme
+  check-readme
   pre-commit
 skip_missing_interpreters = True
 
@@ -26,7 +26,7 @@ deps =
   pytest-cov
 usedevelop = True
 
-[testenv:check_readme]
+[testenv:check-readme]
 description = check that the long description is valid (need for PyPi)
 deps =
   twine
@@ -36,7 +36,7 @@ commands =
   pip wheel -w {envtmpdir}/build --no-deps .
   twine check {envtmpdir}/build/*
 
-[testenv:pre_commit]
+[testenv:pre-commit]
 deps =
   pre-commit
 commands =


### PR DESCRIPTION
Could be also done with "_" all together, but must be consistent.