### PR TITLE
update: Parallel DB locks watcher

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,5 +1,5 @@
 [flake8]
-max-line-length = 80
+max-line-length = 88
 max-complexity = 16
 # B = bugbear
 # B9 = bugbear opinionated (incl line length)

--- a/README.rst
+++ b/README.rst
@@ -183,14 +183,31 @@ click-odoo-update (beta)
     update based on a hash of their file content, compared to the hashes
     stored in the database.
 
+    It allows updating in parallel while another Odoo instance is still
+    running against the same database, by using a watcher that aborts the
+    update in case a DB lock happens.
+
   Options:
-    -c, --config FILE    ...
-    -d, --database TEXT  ...
-    ...
-    --i18n-overwrite     Overwrite existing translations
-    --update-all         Force a complete upgrade (-u base)
-    --if-exists          Don't report error if database doesn't exist
-    --help               Show this message and exit.
+    -c, --config FILE            Specify the Odoo configuration file. Other ways
+                                 to provide it are with the ODOO_RC or
+                                 OPENERP_SERVER environment variables, or
+                                 ~/.odoorc (Odoo >= 10) or ~/.openerp_serverrc.
+    --addons-path TEXT           Specify the addons path. If present, this
+                                 parameter takes precedence over the addons path
+                                 provided in the Odoo configuration file.
+    -d, --database TEXT          Specify the database name. If present, this
+                                 parameter takes precedence over the database
+                                 provided in the Odoo configuration file.
+    --log-level TEXT             Specify the logging level. Accepted values
+                                 depend on the Odoo version, and include debug,
+                                 info, warn, error.  [default: info]
+    --logfile FILE               Specify the log file.
+    --i18n-overwrite             Overwrite existing translations
+    --update-all                 Force a complete upgrade (-u base)
+    --if-exists                  Don't report error if database doesn't exist
+    --watcher-max-seconds FLOAT  Max DB lock seconds allowed before aborting the
+                                 update process. Default: 0 (disabled).
+    --help                       Show this message and exit.
 
 click-odoo-upgrade (deprecated, see click-odoo-update)
 ------------------------------------------------------

--- a/tests/test_update.py
+++ b/tests/test_update.py
@@ -123,3 +123,18 @@ def test_update_i18n_overwrite(odoodb):
     ]
     subprocess.check_call(cmd)
     # TODO how to test i18n-overwrite was effectively applied?
+
+
+def test_parallel_watcher(odoodb):
+    # Test that the parallel updater does not disturb normal operation
+    cmd = [
+        sys.executable,
+        "-m",
+        "click_odoo_contrib.update",
+        "--watcher-max-seconds",
+        "30",
+        "-d",
+        odoodb,
+    ]
+    subprocess.check_call(cmd)
+    # TODO Test an actual lock


### PR DESCRIPTION
With this patch, if you update a database while another Odoo instance is running (such as i.e. a production instance), the production instance will not be locked just because there's a DB lock.

DB locks can happen i.e. when 2 or more transactions are happening in parallel and one of them wants to modify data in a field while another one is modifying the field itself. For example, imagine that a user is modifying a `res.partner`'s name, while another update process is adding a `UNIQUE` constraint in the `name` field of the `res_partner` table. This would produce a deadlock where each transaction is waiting for the other one to finish, and thus both the production instance and the update instance would be locked infinitely until one of them is aborted.

You cannot detect such problem with common tools such as timeouts, because there still exists the possibility of a query being slow without actually being locked, like when you update an addon that has a pre-update migration script that performs lots of work, or when your queries or server are not optimized and perform slowly.

So, the only way to detect deadlocks is by issuing a separate DB cursor that is not protected by a transaction and that watches other cursors' transactions and their locks.

With this change, this is what happens now behind the scenes:

- The DB update process is spawned in background.
- The foreground process uses a separate watcher cursor and watches for locks.
- If a lock is detected, the update process is aborted, giving priority to the other cursors. This is by design because your production users have priority always, and all that would happen is that the update transaction would be rolled back, so you can just try updating again later.
- A couple of CLI parameters allow you to modify the watcher behavior.

---

BTW, the changes in pre-commit are because I have Fedora, where the py3 version is 3.7. I guess this change will help other contributors too, to avoid pre-commit failures...

@Tecnativa