### PR TITLE
[FIX] Odoo not compatible with pyyaml 5.1

### DIFF
--- a/tests/scripts/install_odoo.py
+++ b/tests/scripts/install_odoo.py
@@ -42,6 +42,8 @@ def clone_odoo():
 
 
 def install_odoo():
+    # Odoo not compatible with recent pyyaml due to load() now being safe by default
+    subprocess.check_call(["pip", "install", "pyyaml<4"])
     subprocess.check_call(["pip", "install", "-e", odoo_dir])
 
 


### PR DESCRIPTION
Because Odoo < 11 does not work with the latest pyyaml