### PR TITLE
[FIX] Use parse_version to compare versions

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,6 +1,10 @@
 Changes
 ~~~~~~~
 
+1.7.1 (2019-09-30)
+------------------
+- Support Odoo SaaS versions
+
 1.7.0 (2019-09-02)
 ------------------
 - makepot: always check validity of .po files

--- a/click_odoo_contrib/initdb.py
+++ b/click_odoo_contrib/initdb.py
@@ -19,6 +19,7 @@ from .manifest import expand_dependencies
 from .update import _save_installed_checksums
 
 _logger = logging.getLogger(__name__)
+_odoo_version = odoo.tools.parse_version(odoo.release.version)
 
 
 EXCLUDE_PATTERNS = ("*.pyc", "*.pyo")
@@ -48,9 +49,9 @@ def _patch_ir_attachment_store(force_db_storage):
         # make sure attachments created during db initialization
         # are stored in database, so we get something consistent
         # when recreating the db by copying the cached template
-        if odoo.release.version_info[0] >= 12:
+        if _odoo_version >= odoo.tools.parse_version("12"):
             from odoo.addons.base.models.ir_attachment import IrAttachment
-        elif odoo.release.version_info[0] >= 10:
+        elif _odoo_version >= odoo.tools.parse_version("10"):
             from odoo.addons.base.ir.ir_attachment import IrAttachment
         else:
             from openerp.addons.base.ir.ir_attachment import (
@@ -69,7 +70,7 @@ def odoo_createdb(dbname, demo, module_names, force_db_storage):
         odoo.service.db._create_empty_database(dbname)
         odoo.tools.config["init"] = dict.fromkeys(module_names, 1)
         odoo.tools.config["without_demo"] = not demo
-        if odoo.release.version_info[0] < 10:
+        if _odoo_version < odoo.tools.parse_version("10"):
             Registry = odoo.modules.registry.RegistryManager
         else:
             Registry = odoo.modules.registry.Registry

--- a/click_odoo_contrib/update.py
+++ b/click_odoo_contrib/update.py
@@ -89,7 +89,7 @@ def OdooEnvironmentWithUpdate(database, ctx, **kwargs):
             )
     if ctx.params["i18n_overwrite"]:
         odoo.tools.config["overwrite_existing_translations"] = True
-    if odoo.release.version_info[0] < 10:
+    if odoo.tools.parse_version(odoo.release.version) < odoo.tools.parse_version("10"):
         Registry = odoo.modules.registry.RegistryManager
     else:
         Registry = odoo.modules.registry.Registry

--- a/tests/test_manifest.py
+++ b/tests/test_manifest.py
@@ -32,7 +32,7 @@ def test_manifest_expand_dependencies():
     assert "base_import" in res
     assert "base" in res  # obviously
     assert "web" in res  # base_import depends on web
-    if odoo.release.version_info[0] < 12:
+    if odoo.tools.parse_version(odoo.release.version) < odoo.tools.parse_version("12"):
         assert "auth_crypt" not in res
     else:
         assert "iap" not in res  # iap is auto_install
@@ -42,7 +42,7 @@ def test_manifest_expand_dependencies_auto_install():
     res = manifest.expand_dependencies(["auth_signup"], include_auto_install=True)
     assert "auth_signup" in res
     assert "base" in res  # obviously
-    if odoo.release.version_info[0] < 12:
+    if odoo.tools.parse_version(odoo.release.version) < odoo.tools.parse_version("12"):
         assert "auth_crypt" in res  # auth_crypt is autoinstall
     else:
         assert "iap" in res  # iap is auto_install

--- a/tests/test_update.py
+++ b/tests/test_update.py
@@ -98,7 +98,7 @@ def test_update(odoodb):
     _check_expected(odoodb, "v6")
     with pytest.raises(subprocess.CalledProcessError):
         _update_one(odoodb, "v7")
-    if odoo.release.version_info[0] >= 12:
+    if odoo.tools.parse_version(odoo.release.version) >= odoo.tools.parse_version("12"):
         # Odoo >= 12 does -u in a transaction
         _check_expected(odoodb, "v6")
 


### PR DESCRIPTION

This is WIP until https://github.com/acsone/click-odoo/pull/31 is released. It makes use of that new feature in click-odoo to allow running these scripts in pre-release versions.

@Tecnativa TT19268