### PR TITLE
Support existing-but-not-initialized databases in init script

### DIFF
--- a/click_odoo_contrib/_dbutils.py
+++ b/click_odoo_contrib/_dbutils.py
@@ -9,8 +9,8 @@ from click_odoo import odoo
 
 
 @contextmanager
-def pg_connect():
-    conn = odoo.sql_db.db_connect("postgres")
+def pg_connect(dbname="postgres"):
+    conn = odoo.sql_db.db_connect(dbname)
     cr = conn.cursor()
     cr.autocommit(True)
     try:
@@ -27,6 +27,13 @@ def db_exists(dbname):
             (dbname,),
         )
         return bool(cr.fetchone())
+
+
+def db_initialized(dbname):
+    if not db_exists(dbname):
+        return False
+    with pg_connect(dbname) as cr:
+        return odoo.modules.db.is_initialized(cr)
 
 
 def terminate_connections(dbname):


### PR DESCRIPTION
Since https://github.com/odoo/odoo/commit/cb2862ad2a60ff4ce66c14e7af2548fdf6fc5961 (v12+), Odoo will not autoinitialize modules in a database that already exists.

However, in v8-, Odoo will not start if the database doesn't exist.

To make this difference easier to handle, with this change, `click-odoo-initdb` will treat non-existing databases the same as non-initialized ones (which is, for Odoo, the same).

@Tecnativa TT20713