### PR TITLE
click-odoo-update: add dry-run option to evaluate addons to update before actually updating.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -207,6 +207,8 @@ click-odoo-update (stable)
     --if-exists                  Don't report error if database doesn't exist
     --watcher-max-seconds FLOAT  Max DB lock seconds allowed before aborting the
                                  update process. Default: 0 (disabled).
+    --list-only                  Log the list of addons to update without
+                                 actually updating them.
     --help                       Show this message and exit.
 
 Useful links
@@ -242,9 +244,11 @@ Contributors:
 - Benjamin Willig (ACSONE_)
 - Jairo Llopis (Tecnativa_)
 - Laurent Mignon (ACSONE_)
+- Lois Rilo (ForgeFlow_)
 
 .. _ACSONE: https://acsone.eu
 .. _Tecnativa: https://tecnativa.com
+.. _ForgeFlow: https://forgeflow.com
 
 Maintainer
 ~~~~~~~~~~

--- a/newsfragments/68.feature
+++ b/newsfragments/68.feature
@@ -1,0 +1,1 @@
+added --list-only option to click-odoo-update.

--- a/tests/test_update.py
+++ b/tests/test_update.py
@@ -77,9 +77,27 @@ def _update_one(odoodb, v):
     subprocess.check_call(cmd)
 
 
+def _update_list(odoodb, v):
+    cmd = [
+        sys.executable,
+        "-m",
+        "click_odoo_contrib.update",
+        "--addons-path",
+        _addons_path(v),
+        "-d",
+        odoodb,
+        "--list-only",
+    ]
+    subprocess.check_call(cmd)
+
+
 def test_update(odoodb):
     _install_one(odoodb, "v1")
     _check_expected(odoodb, "v1")
+    # With --list-only option update shouldn't be performed:
+    _update_list(odoodb, "v2")
+    _check_expected(odoodb, "v1")
+    # Default update should:
     _update_one(odoodb, "v2")
     _check_expected(odoodb, "v2")
     _update_one(odoodb, "v3")


### PR DESCRIPTION
This allows to anticipate better the impact of an update. Let me know if this approach is correct and/or if it needs any change.

Awesome project BTW :)

@ForgeFlow