### PR TITLE
enable copying filestore in diff mode

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -37,6 +37,8 @@ click-odoo-copydb (beta)
                             exists.
     --if-source-exists      Don't report error if source database does not
                             exist.
+    --filestore-diff        Only copy new files in filestore
+                            (needs python >= 3.8).
     --help                  Show this message and exit.
 
 click-odoo-dropdb (stable)


### PR DESCRIPTION
This is useful if filestore for one db `copy` that is a copy of `base` mounted on top of the base filestore via a filesystem that facilitates deduplication of assets in the root filesystem (e.g. mounting `copy` onto `base` with https://manpages.debian.org/jessie/aufs-tools/mount.aufs.8.en.html)

And also should improve performance of copydb if filestore already exists and one only needs to copy the changes (new files only).

Info @wt-io-it