### PR TITLE
enable copying filestore in diff mode

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -281,7 +281,7 @@ Development
 
 To run tests, type ``tox``. Tests are made using pytest. To run tests matching
 a specific keyword for, say, Odoo 12 and python 3.6, use
-``tox -e py36-12.0 -- -k keyword``.
+``tox -e py36-12.0 -- -k keyword``. For running tests you need a postgres server accessible for your user without a password at ``/var/run/postgresql/.s.PGSQL.5432``.
 
 This project uses `black <https://github.com/ambv/black>`_
 as code formatting convention, as well as isort and flake8.

--- a/README.rst
+++ b/README.rst
@@ -37,12 +37,16 @@ click-odoo-copydb (beta)
                             exists.
     --if-source-exists      Don't report error if source database does not
                             exist.
-    --filestore-copy-mode   [default|rsync]
+    --filestore-copy-mode   [default|rsync|hardlink]
                             Mode for copying the filestore. Default uses
                             python shutil copytree which copies
                             everything. If the target filestore already
                             exists and just needs an update you can use
-                            rsync to rsync the filestore instead.
+                            rsync to rsync the filestore instead. If both
+                            filestores are on the same filesystem supporting
+                            hardlinks you can use the option hardlink to hard
+                            link the files to the inodes of the files of the
+                            source directory which saves on space on the disk.
     --help                  Show this message and exit.
 
 click-odoo-dropdb (stable)

--- a/README.rst
+++ b/README.rst
@@ -37,6 +37,8 @@ click-odoo-copydb (beta)
                             exists.
     --if-source-exists      Don't report error if source database does not
                             exist.
+    --filestore-diff        Only copy differences in filestore
+                            (needs rsync installed).
     --help                  Show this message and exit.
 
 click-odoo-dropdb (stable)

--- a/README.rst
+++ b/README.rst
@@ -37,8 +37,12 @@ click-odoo-copydb (beta)
                             exists.
     --if-source-exists      Don't report error if source database does not
                             exist.
-    --filestore-diff        Only copy differences in filestore
-                            (needs rsync installed).
+    --filestore-copy-mode   [default|rsync]
+                            Mode for copying the filestore. Default uses
+                            python shutil copytree which copies
+                            everything. If the target filestore already
+                            exists and just needs an update you can use
+                            rsync to rsync the filestore instead.
     --help                  Show this message and exit.
 
 click-odoo-dropdb (stable)

--- a/click_odoo_contrib/copydb.py
+++ b/click_odoo_contrib/copydb.py
@@ -50,6 +50,12 @@ def _copy_filestore(source, dest, copy_mode="default"):
                     ]
                 )
                 subprocess.check_call(cmd)
+            # we use one generic exception clause here because subprocess.check_call
+            # may not only raise the documented  subprocess.CalledProcessError
+            # (when the command exits with a return code != 0) but also with at least a
+            # few other Exceptions like PermissionError when the given command is not
+            # executable (by the current user) or a FileNotFoundError if the given
+            # command is not in the users PATH or cannot be found on the system
             except Exception as e:
                 msg = "Error syncing filestore to: {}, {}".format(dest, e)
                 raise click.ClickException(msg)

--- a/newsfragments/86.feature
+++ b/newsfragments/86.feature
@@ -1,2 +1,2 @@
-Adding a new option to enable using rsync for copying filestore.
-  --filestore-copy-mode   [default|rsync]
+Adding a new option to enable using rsync and hardlinks for copying filestore.
+  --filestore-copy-mode   [default|rsync|hardlink]

--- a/newsfragments/86.feature
+++ b/newsfragments/86.feature
@@ -1,0 +1,2 @@
+Adding a new option to enable using rsync for copying filestore.
+  --filestore-copy-mode   [default|rsync]

--- a/tests/test_copydb.py
+++ b/tests/test_copydb.py
@@ -56,6 +56,15 @@ def _assert_ir_config_reset(db1, db2):
         assert v != params2[k]
 
 
+def _has_rsync():
+    try:
+        subprocess.check_call(["which", "rsync"])
+        return True
+    except subprocess.CalledProcessError as e:
+        print(e)
+        return False
+
+
 @pytest.fixture
 def filestore():
     filestore_dir = odoo.tools.config.filestore(TEST_DBNAME)
@@ -190,3 +199,84 @@ def test_copydb_no_source_filestore(odoodb, ir_config_param_test_values):
         assert not os.path.isdir(filestore_dir_new)
     finally:
         _dropdb(TEST_DBNAME_NEW)
+
+
+@pytest.mark.skipif(not _has_rsync(), reason="Cannot find `rsync` on test system")
+def test_copydb_rsync(odoodb):
+    # given an db with an existing filestore directory
+    filestore_dir_new = odoo.tools.config.filestore(TEST_DBNAME_NEW)
+    filestore_dir_original = odoo.tools.config.filestore(odoodb)
+    if not os.path.exists(filestore_dir_original):
+        os.makedirs(filestore_dir_original)
+    try:
+        # when running copydb with mode rsync
+        result = CliRunner().invoke(
+            main, ["--filestore-copy-mode=rsync", odoodb, TEST_DBNAME_NEW]
+        )
+
+        # then the sync should be successful
+        assert result.exit_code == 0
+        # and the new db should exist
+        _assert_ir_config_reset(odoodb, TEST_DBNAME_NEW)
+        # and the filestore directory for the copied db should have been created
+        assert os.path.isdir(filestore_dir_new)
+    finally:
+        # cleanup: drop copied db and created filestore dir
+        _dropdb(TEST_DBNAME_NEW)
+        if os.path.isdir(filestore_dir_new):
+            shutil.rmtree(filestore_dir_new)
+
+
+@pytest.mark.skipif(not _has_rsync(), reason="Cannot find `rsync` on test system")
+def test_copydb_rsync_preexisting_filestore_dir(odoodb):
+    # given an db with an existing filestore directory
+    filestore_dir_new = odoo.tools.config.filestore(TEST_DBNAME_NEW)
+    filestore_dir_original = odoo.tools.config.filestore(odoodb)
+    if not os.path.exists(filestore_dir_original):
+        os.makedirs(filestore_dir_original)
+    # and an existing target filestore
+    if not os.path.exists(filestore_dir_new):
+        os.makedirs(filestore_dir_new)
+    try:
+        # when running copydb with mode rsync
+        result = CliRunner().invoke(
+            main, ["--filestore-copy-mode=rsync", odoodb, TEST_DBNAME_NEW]
+        )
+
+        # then the sync should be successful
+        assert result.exit_code == 0
+        # and the new db should exist
+        _assert_ir_config_reset(odoodb, TEST_DBNAME_NEW)
+        # and the filestore directory for the copied db should have been created
+        assert os.path.isdir(filestore_dir_new)
+    finally:
+        # cleanup: drop copied db and created filestore dir
+        _dropdb(TEST_DBNAME_NEW)
+        if os.path.isdir(filestore_dir_new):
+            shutil.rmtree(filestore_dir_new)
+
+
+@pytest.mark.skipif(not _has_rsync(), reason="Cannot find `rsync` on test system")
+def test_copydb_rsync_hardlinks(odoodb):
+    # given an db with an existing filestore directory
+    filestore_dir_new = odoo.tools.config.filestore(TEST_DBNAME_NEW)
+    filestore_dir_original = odoo.tools.config.filestore(odoodb)
+    if not os.path.exists(filestore_dir_original):
+        os.makedirs(filestore_dir_original)
+    try:
+        # when running copydb with mode rsync
+        result = CliRunner().invoke(
+            main, ["--filestore-copy-mode=hardlink", odoodb, TEST_DBNAME_NEW]
+        )
+
+        # then the sync should be successful
+        assert result.exit_code == 0
+        # and the new db should exist
+        _assert_ir_config_reset(odoodb, TEST_DBNAME_NEW)
+        # and the filestore directory for the copied db should have been created
+        assert os.path.isdir(filestore_dir_new)
+    finally:
+        # cleanup: drop copied db and created filestore dir
+        _dropdb(TEST_DBNAME_NEW)
+        if os.path.isdir(filestore_dir_new):
+            shutil.rmtree(filestore_dir_new)


### PR DESCRIPTION
This is useful if filestore for one db `copy` that is a copy of `base` mounted on top of the base filestore via a filesystem that facilitates deduplication of assets in the root filesystem (e.g. mounting `copy` onto `base` with https://manpages.debian.org/jessie/aufs-tools/mount.aufs.8.en.html)

And also should improve performance of copydb if filestore already exists and one only needs to copy the changes (new files only).

Info @wt-io-it