### PR TITLE
Add --no-fuzzy-matching option to makepot

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -189,6 +189,12 @@ click-odoo-makepot (stable)
                                 Only applies when --msgmerge
                                 or --msgmerge-if-new-pot are passed.
                                 [default: True]
+    --purge-old-translations /  --no-purge-old-translations
+                                Remove comment lines containing old
+                                translations from .po files.
+                                Only applies when --msgmerge
+                                or --msgmerge-if-new-pot are passed.
+                                [default: False]
     --commit / --no-commit      Git commit exported .pot files if needed.
                                 [default: False]
     --help                      Show this message and exit.

--- a/README.rst
+++ b/README.rst
@@ -183,6 +183,12 @@ click-odoo-makepot (stable)
                                 Merge .pot changes into all .po files, only
                                 if a new .pot file has been created.
                                 [default: False]
+    --fuzzy-matching /  --no-fuzzy-matching
+                                Use fuzzy matching when merging .pot changes
+                                into .po files.
+                                Only applies when --msgmerge
+                                or --msgmerge-if-new-pot are passed.
+                                [default: True]
     --commit / --no-commit      Git commit exported .pot files if needed.
                                 [default: False]
     --help                      Show this message and exit.

--- a/click_odoo_contrib/makepot.py
+++ b/click_odoo_contrib/makepot.py
@@ -30,6 +30,7 @@ def export_pot(
     msgmerge_if_new_pot,
     commit_message,
     fuzzy_matching,
+    purge_old_translations,
 ):
     addon_name = module.name
     addon_dir = os.path.join(addons_dir, addon_name)
@@ -67,6 +68,15 @@ def export_pot(
                 if not fuzzy_matching:
                     cmd.append("--no-fuzzy-matching")
                 subprocess.check_call(cmd)
+                # Purge old translations
+                if purge_old_translations:
+                    cmd = [
+                        "msgattrib",
+                        "--output-file=%s" % lang_filepath,
+                        "--no-obsolete",
+                        lang_filepath,
+                    ]
+                    subprocess.check_call(cmd)
             else:
                 # check .po is valid
                 subprocess.check_output(
@@ -107,6 +117,13 @@ def export_pot(
     "Only applies when --msgmerge or --msgmerge-if-new-pot are passed.",
 )
 @click.option(
+    "--purge-old-translations / --no-purge-old-translations",
+    show_default=True,
+    default=False,
+    help="Remove comment lines containing old translations from .po files. "
+    "Only applies when --msgmerge or --msgmerge-if-new-pot are passed.",
+)
+@click.option(
     "--commit / --no-commit",
     show_default=True,
     help="Git commit exported .pot files if needed.",
@@ -122,6 +139,7 @@ def main(
     msgmerge_if_new_pot,
     commit_message,
     fuzzy_matching,
+    purge_old_translations,
 ):
     """Export translation (.pot) files of addons
     installed in the database and present in addons_dir.
@@ -144,6 +162,7 @@ def main(
                 msgmerge_if_new_pot,
                 commit_message,
                 fuzzy_matching,
+                purge_old_translations,
             )
 
 

--- a/click_odoo_contrib/makepot.py
+++ b/click_odoo_contrib/makepot.py
@@ -22,7 +22,14 @@ POT_FILE_EXT = ".pot"
 
 
 def export_pot(
-    env, module, addons_dir, msgmerge, commit, msgmerge_if_new_pot, commit_message
+    env,
+    module,
+    addons_dir,
+    msgmerge,
+    commit,
+    msgmerge_if_new_pot,
+    commit_message,
+    fuzzy_matching,
 ):
     addon_name = module.name
     addon_dir = os.path.join(addons_dir, addon_name)
@@ -56,9 +63,10 @@ def export_pot(
         try:
             if msgmerge or (msgmerge_if_new_pot and pot_is_new):
                 files_to_commit.add(lang_filepath)
-                subprocess.check_call(
-                    ["msgmerge", "--quiet", "-U", lang_filepath, pot_filepath]
-                )
+                cmd = ["msgmerge", "--quiet", "-U", lang_filepath, pot_filepath]
+                if not fuzzy_matching:
+                    cmd.append("--no-fuzzy-matching")
+                subprocess.check_call(cmd)
             else:
                 # check .po is valid
                 subprocess.check_output(
@@ -92,6 +100,13 @@ def export_pot(
     "a new .pot file has been created.",
 )
 @click.option(
+    "--fuzzy-matching / --no-fuzzy-matching",
+    show_default=True,
+    default=True,
+    help="Use fuzzy matching when merging .pot changes into .po files. "
+    "Only applies when --msgmerge or --msgmerge-if-new-pot are passed.",
+)
+@click.option(
     "--commit / --no-commit",
     show_default=True,
     help="Git commit exported .pot files if needed.",
@@ -99,7 +114,15 @@ def export_pot(
 @click.option(
     "--commit-message", show_default=True, default="[UPD] Update {addon_name}.pot"
 )
-def main(env, addons_dir, msgmerge, commit, msgmerge_if_new_pot, commit_message):
+def main(
+    env,
+    addons_dir,
+    msgmerge,
+    commit,
+    msgmerge_if_new_pot,
+    commit_message,
+    fuzzy_matching,
+):
     """Export translation (.pot) files of addons
     installed in the database and present in addons_dir.
     Check that existing .po file are syntactically correct.
@@ -120,6 +143,7 @@ def main(env, addons_dir, msgmerge, commit, msgmerge_if_new_pot, commit_message)
                 commit,
                 msgmerge_if_new_pot,
                 commit_message,
+                fuzzy_matching,
             )
 
 

--- a/tests/data/test_makepot/addon_test_makepot/i18n/fr.po.fuzzy
+++ b/tests/data/test_makepot/addon_test_makepot/i18n/fr.po.fuzzy
@@ -1,0 +1,20 @@
+#. module: addon_test_makepot
+#: model:ir.model.fields,field_description:addon_test_makepot.field_test_model_create_uid
+msgid "Created on"
+msgstr ""
+
+#. module: addon_test_makepot
+#: model:ir.model.fields,field_description:addon_test_makepot.field_test_model_create_date
+msgid "Created on"
+msgstr ""
+
+#. module: addon_test_makepot
+#: model:ir.model.fields,field_description:addon_test_makepot.field_test_model_display_name
+msgid "Display Name"
+msgstr ""
+
+#. module: addon_test_makepot
+#: model:ir.model.fields,field_description:addon_test_makepot.field_test_model_id
+#, fuzzy
+msgid "ID"
+msgstr ""

--- a/tests/data/test_makepot/addon_test_makepot/i18n/fr.po.old
+++ b/tests/data/test_makepot/addon_test_makepot/i18n/fr.po.old
@@ -1,0 +1,35 @@
+#. module: addon_test_makepot
+#: model:ir.model.fields,field_description:addon_test_makepot.field_test_model_create_uid
+msgid "Created on"
+msgstr ""
+
+#. module: addon_test_makepot
+#: model:ir.model.fields,field_description:addon_test_makepot.field_test_model_create_date
+msgid "Created on"
+msgstr ""
+
+#. module: addon_test_makepot
+#: model:ir.model.fields,field_description:addon_test_makepot.field_test_model_display_name
+msgid "Display Name"
+msgstr ""
+
+#. module: addon_test_makepot
+#: model:ir.model.fields,field_description:addon_test_makepot.field_test_model_id
+#, fuzzy
+msgid "ID"
+msgstr ""
+
+#~ msgid "Last Modified on"
+#~ msgstr ""
+
+#~ msgid "Last Updated by"
+#~ msgstr ""
+
+#~ msgid "Last Updated on"
+#~ msgstr ""
+
+#~ msgid "Myfield"
+#~ msgstr ""
+
+#~ msgid "test.model"
+#~ msgstr ""


### PR DESCRIPTION
Allow adding `--no-fuzzy-matching` flag to `msgmerge` command through makepot command line flag.

Allow for adding `--purge-old-translations` flag to remove old translation as comments in generated .po files.

@Tecnativa
TT26747

ping @Yajo  