### PR TITLE
click-odoo-update: also consider modules in 'to upgrade' state

### DIFF
--- a/click_odoo_contrib/update.py
+++ b/click_odoo_contrib/update.py
@@ -203,7 +203,10 @@ def _update_db_nolock(
     else:
         with conn.cursor() as cr:
             checksums = _load_installed_checksums(cr)
-            cr.execute("SELECT name FROM ir_module_module WHERE state = 'installed'")
+            cr.execute(
+                "SELECT name FROM ir_module_module "
+                "WHERE state in ('installed', 'to upgrade')"
+            )
             for (module_name,) in cr.fetchall():
                 if not _is_installable(module_name):
                     # if the module is not installable, do not try to update it

--- a/newsfragments/97.feature
+++ b/newsfragments/97.feature
@@ -1,0 +1,3 @@
+click-odoo-update: also pass all modified modules in ``to upgrade`` state to
+Odoo for update; this helps upgrading when there are new dependencies, in
+combination with Odoo `#72661 <https://github.com/odoo/odoo/pull/72661>`__.


### PR DESCRIPTION
This should not be necessary, but it does no harm.

And it helps in combination with https://github.com/odoo/odoo/pull/72661 until a better solution is found in Odoo core.
