### PR TITLE
Silence Odoo 15 noisy warnings about using autocommit

### DIFF
--- a/click_odoo_contrib/_dbutils.py
+++ b/click_odoo_contrib/_dbutils.py
@@ -3,6 +3,7 @@
 # License LGPL-3.0 or later (http://www.gnu.org/licenses/lgpl.html).
 
 import hashlib
+import warnings
 from contextlib import contextmanager
 
 from click_odoo import OdooEnvironment, odoo
@@ -12,7 +13,11 @@ from click_odoo import OdooEnvironment, odoo
 def pg_connect():
     conn = odoo.sql_db.db_connect("postgres")
     cr = conn.cursor()
-    cr.autocommit(True)
+    # We are not going to use the ORM with this connection
+    # so silence the Odoo warning about autocommit.
+    with warnings.catch_warnings():
+        warnings.filterwarnings("ignore")
+        cr.autocommit(True)
     try:
         yield cr._obj
     finally:

--- a/newsfragments/105.bugfix
+++ b/newsfragments/105.bugfix
@@ -1,0 +1,1 @@
+Silence Odoo 15 noisy warnings about using autocommit.

--- a/tests/test_initdb.py
+++ b/tests/test_initdb.py
@@ -13,6 +13,7 @@ import pytest
 from click.testing import CliRunner
 
 from click_odoo_contrib import initdb
+from click_odoo_contrib._dbutils import pg_connect
 from click_odoo_contrib.initdb import DbCache, main
 
 TEST_DBNAME = "click-odoo-contrib-testinitdb"
@@ -48,7 +49,8 @@ def pgdb():
 
 @pytest.fixture
 def dbcache():
-    with DbCache(TEST_PREFIX) as c:
+    with pg_connect() as pgcr:
+        c = DbCache(TEST_PREFIX, pgcr)
         try:
             yield c
         finally:


### PR DESCRIPTION
This usage is safe are we are not using the ORM but the underlying pg cursor.

closes #105 