### PR TITLE
Resolves #112: resetdb and listdb

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -142,6 +142,33 @@ click-odoo-backupdb (beta)
     --filestore / --no-filestore  Include filestore in backup  [default: True]
     --help                        Show this message and exit.
 
+click-odoo-resetdb (beta)
+---------------------------
+
+.. code::
+
+  Usage: click-odoo-resetdb [OPTIONS] DBNAME
+
+    Reset an Odoo database.
+
+    This script allows you to reset the configuration of a database.
+
+  Options:
+    -c, --config FILE  ...
+    ...
+    --if-exists        Don't reset if the database does not exist.
+
+    --reset-config     Reset the configuration.
+                       [default: True]
+
+    --disable-cron     Disable CRON jobs.
+
+    --disable-mail     Disable mail servers.
+
+    --set-password P   Set password P on all users.
+
+    --help             Show this message and exit.
+
 click-odoo-restoredb (beta)
 ---------------------------
 

--- a/README.rst
+++ b/README.rst
@@ -167,6 +167,8 @@ click-odoo-resetdb (beta)
 
     --set-password P   Set password P on all users.
 
+    --wipe-config KS   Set blank value for the given system configuration
+
     --help             Show this message and exit.
 
 click-odoo-restoredb (beta)

--- a/click_odoo_contrib/listdb.py
+++ b/click_odoo_contrib/listdb.py
@@ -12,7 +12,7 @@ from ._dbutils import (
 
 @click.command()
 @click_odoo.env_options(
-    default_log_level="warn", with_database=False,
+    default_log_level="warn", with_database=False, with_rollback=False,
 )
 def main(
     env,
@@ -21,7 +21,7 @@ def main(
 
     This script just lists the databases.
     """
-    dbname = env.dbname
+    dbname = ''  # XXX find the default database name
     with db_management_enabled():
         databases = odoo.service.db.list_dbs(True)
     # print the list

--- a/click_odoo_contrib/listdb.py
+++ b/click_odoo_contrib/listdb.py
@@ -1,0 +1,34 @@
+#!/usr/bin/env python
+# License LGPL-3.0 or later (http://www.gnu.org/licenses/lgpl.html).
+
+import click
+import click_odoo
+from click_odoo import odoo
+
+from ._dbutils import (
+    db_management_enabled,
+)
+
+
+@click.command()
+@click_odoo.env_options(
+    default_log_level="warn", with_database=False,
+)
+def main(
+    env,
+):
+    """List available Odoo databases.
+
+    This script just lists the databases.
+    """
+    dbname = env.dbname
+    with db_management_enabled():
+        databases = odoo.service.db.list_dbs(True)
+    # print the list
+    for database in databases:
+        msg = "{}{}".format(database, ' *' if database == dbname else '')
+        click.echo(click.style(msg))
+
+
+if __name__ == "__main__":  # pragma: no cover
+    main()

--- a/click_odoo_contrib/listdb.py
+++ b/click_odoo_contrib/listdb.py
@@ -5,9 +5,7 @@ import click
 import click_odoo
 from click_odoo import odoo
 
-from ._dbutils import (
-    db_management_enabled,
-)
+from ._dbutils import db_management_enabled
 
 
 @click.command()
@@ -21,12 +19,11 @@ def main(
 
     This script just lists the databases.
     """
-    dbname = ''  # XXX find the default database name
     with db_management_enabled():
         databases = odoo.service.db.list_dbs(True)
     # print the list
     for database in databases:
-        msg = "{}{}".format(database, ' *' if database == dbname else '')
+        msg = " {}".format(database)
         click.echo(click.style(msg))
 
 

--- a/click_odoo_contrib/resetdb.py
+++ b/click_odoo_contrib/resetdb.py
@@ -1,0 +1,110 @@
+#!/usr/bin/env python
+# License LGPL-3.0 or later (http://www.gnu.org/licenses/lgpl.html).
+
+import click
+import click_odoo
+
+from ._dbutils import (
+    db_exists,
+    reset_config_parameters,
+)
+
+
+@click.command()
+@click_odoo.env_options(
+    default_log_level="warn", with_database=True,
+)
+@click.option(
+    "--if-exists",
+    is_flag=True,
+    help="Execute only if database exists",
+)
+@click.option(
+    "--reset-config",
+    is_flag=True,
+    default=True,
+    help="Reset the system configuration",
+)
+@click.option(
+    "--set-password",
+    metavar="P",
+    help="Set the password P on all users",
+)
+@click.option(
+    "--disable-cron",
+    is_flag=True,
+    help="Disable all CRON jobs",
+)
+@click.option(
+    "--disable-mail",
+    is_flag=True,
+    help="Disable all mail servers",
+)
+@click.argument("dest", required=True)
+def main(
+    env,
+    dbname,
+    if_exists,
+    reset_config,
+    set_password,
+    disable_cron,
+    disable_mail,
+):
+    """Reset an Odoo database ID and options.
+
+    This script resets system paramters of the given database.
+    """
+    if not db_exists(dbname):
+        msg = "Database does not exist: {}".format(dbname)
+        if if_exists:
+            click.echo(click.style(msg, fg="yellow"))
+            return
+        else:
+            raise click.ClickException(msg)
+    # reset common parameters
+    if reset_config:
+        reset_config_parameters(dbname)
+    # additional changes
+    with click_odoo.OdooEnvironment(dbname) as env:
+        if reset_config:
+            env.cr.execute("""
+            DELETE FROM ir_attachment
+            WHERE name like '%.assets_%' AND public = true;
+
+            BEGIN
+                UPDATE auth_oauth_provider SET enabled = False;
+            EXCEPTION WHEN undefined_table THEN
+            END;
+            """)
+        if disable_cron:
+            env.cr.execute("""
+            UPDATE ir_cron SET active = false;
+            UPDATE ir_cron SET active = true
+            WHERE id IN (
+                SELECT res_id
+                FROM ir_model_data
+                WHERE model = 'ir.cron'
+                AND (
+                    (module = 'base' AND name = 'autovacuum_job')
+                )
+            );
+            """)
+        if disable_mail:
+            env.cr.execute("""
+            UPDATE ir_mail_server SET active = false;
+            UPDATE mail_template SET mail_server_id = NULL;
+            """)
+        if set_password:
+            # from passlib.context import CryptContext
+            # crypt = CryptContext(schemes=['pbkdf2_sha512'])
+            # encrypted = crypt.encrypt(set_password)
+            password_value = set_password
+            env.cr.execute("""
+            UPDATE res_users SET password = '{}';
+            """.format(password_value.replace("'", "''")))
+    msg = "Database is reset: {}".format(dbname)
+    click.echo(click.style(msg))
+
+
+if __name__ == "__main__":  # pragma: no cover
+    main()

--- a/setup.py
+++ b/setup.py
@@ -45,13 +45,13 @@ setup(
     entry_points="""
         [console_scripts]
         click-odoo-uninstall=click_odoo_contrib.uninstall:main
-        click-odoo-upgrade=click_odoo_contrib.upgrade:main
         click-odoo-update=click_odoo_contrib.update:main
         click-odoo-copydb=click_odoo_contrib.copydb:main
         click-odoo-dropdb=click_odoo_contrib.dropdb:main
         click-odoo-initdb=click_odoo_contrib.initdb:main
         click-odoo-backupdb=click_odoo_contrib.backupdb:main
         click-odoo-restoredb=click_odoo_contrib.restoredb:main
+        click-odoo-resetdb=click_odoo_contrib.resetdb:main
         click-odoo-makepot=click_odoo_contrib.makepot:main
     """,
 )

--- a/setup.py
+++ b/setup.py
@@ -49,6 +49,7 @@ setup(
         click-odoo-copydb=click_odoo_contrib.copydb:main
         click-odoo-dropdb=click_odoo_contrib.dropdb:main
         click-odoo-initdb=click_odoo_contrib.initdb:main
+        click-odoo-listdb=click_odoo_contrib.listdb:main
         click-odoo-backupdb=click_odoo_contrib.backupdb:main
         click-odoo-restoredb=click_odoo_contrib.restoredb:main
         click-odoo-resetdb=click_odoo_contrib.resetdb:main


### PR DESCRIPTION
Reset DB allows to reset the configuration of the database. You can do that just after restoring a production database.
Also listdb is a shortcut to easily list databases, so you know what is available.

Resolves #112 