### PR TITLE
[UPD] adapt click-odoo-update for odoo 16

### DIFF
--- a/click_odoo_contrib/update.py
+++ b/click_odoo_contrib/update.py
@@ -175,7 +175,12 @@ def _get_checksum_dir(cr, module_name):
 
 def _is_installable(module_name):
     try:
-        manifest = odoo.modules.load_information_from_description_file(module_name)
+        if odoo.tools.parse_version(odoo.release.version) <= odoo.tools.parse_version(
+            "15"
+        ):
+            manifest = odoo.modules.load_information_from_description_file(module_name)
+        else:
+            manifest = odoo.modules.get_manifest(module_name)
         return manifest["installable"]
     except Exception:
         # load_information_from_description_file populates default value

--- a/newsfragments/119.bugfix
+++ b/newsfragments/119.bugfix
@@ -1,0 +1,1 @@
+Adapt click-odoo-update for odoo 16.


### PR DESCRIPTION
click-odoo-update does not work after odoo 15

in odoo master this is because load_information_description_file() is deprecated

see https://github.com/odoo/odoo/blob/master/odoo/modules/module.py#L413

I propose this pr to fix this, tested for an odoo 13 and an odoo master