### PR TITLE
Fix click-odoo-update for odoo 15

### DIFF
--- a/click_odoo_contrib/update.py
+++ b/click_odoo_contrib/update.py
@@ -177,7 +177,7 @@ def _get_checksum_dir(cr, module_name):
 def _is_installable(module_name):
     try:
         if odoo.tools.parse_version(odoo.release.version) < odoo.tools.parse_version(
-            "16"
+            "16dev"
         ):
             manifest = odoo.modules.load_information_from_description_file(module_name)
         else:

--- a/click_odoo_contrib/update.py
+++ b/click_odoo_contrib/update.py
@@ -176,9 +176,7 @@ def _get_checksum_dir(cr, module_name):
 
 def _is_installable(module_name):
     try:
-        if odoo.tools.parse_version(odoo.release.version) < odoo.tools.parse_version(
-            "16dev"
-        ):
+        if odoo.release.version_info < (16, 0):
             manifest = odoo.modules.load_information_from_description_file(module_name)
         else:
             manifest = odoo.modules.get_manifest(module_name)

--- a/click_odoo_contrib/update.py
+++ b/click_odoo_contrib/update.py
@@ -176,8 +176,8 @@ def _get_checksum_dir(cr, module_name):
 
 def _is_installable(module_name):
     try:
-        if odoo.tools.parse_version(odoo.release.version) <= odoo.tools.parse_version(
-            "15"
+        if odoo.tools.parse_version(odoo.release.version) < odoo.tools.parse_version(
+            "16"
         ):
             manifest = odoo.modules.load_information_from_description_file(module_name)
         else:


### PR DESCRIPTION
This PR is going to fix issue since #119 

Assume we are using Odoo 15, now we have
`odoo.tools.parse_version("15")` < `odoo.tools.parse_version(odoo.release.version)` < `odoo.tools.parse_version("16")`

Then that condition will return false and `_is_installable` will also return false since `get_manifest` doesn't exists in Odoo 15

So it is better to change the expression to `odoo.tools.parse_version(odoo.release.version)` < `odoo.tools.parse_version("16")` to include all Odoo 15 version