### PR TITLE
[IMP] click-odoo-update: exclude tests from checksum

### DIFF
--- a/click_odoo_contrib/update.py
+++ b/click_odoo_contrib/update.py
@@ -25,7 +25,7 @@ _logger = logging.getLogger(__name__)
 
 PARAM_INSTALLED_CHECKSUMS = "module_auto_update.installed_checksums"
 PARAM_EXCLUDE_PATTERNS = "module_auto_update.exclude_patterns"
-DEFAULT_EXCLUDE_PATTERNS = "*.pyc,*.pyo,i18n/*.pot,i18n_extra/*.pot,static/*"
+DEFAULT_EXCLUDE_PATTERNS = "*.pyc,*.pyo,i18n/*.pot,i18n_extra/*.pot,static/*,tests/*"
 
 
 class DbLockWatcher(threading.Thread):

--- a/newsfragments/125.feature
+++ b/newsfragments/125.feature
@@ -1,0 +1,2 @@
+click-odoo-update: exclude tests/ directory from checksum computation
+A modification in tests alone should not require a database upgrade.


### PR DESCRIPTION
A modification in tests alone should not require a database upgrade.