### PR TITLE
feat(click-odoo-listdb): handy script for listing odooable databases

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -211,6 +211,26 @@ click-odoo-makepot (stable)
                                 [default: False]
     --help                      Show this message and exit.
 
+click-odoo-listdb (beta)
+------------------------
+
+.. code::
+
+  Usage: click-odoo-listdb [OPTIONS]
+
+    List Odoo databases.
+
+  Options:
+    -c, --config FILE  Specify the Odoo configuration file. Other ways to
+                      provide it are with the ODOO_RC or OPENERP_SERVER
+                      environment variables, or ~/.odoorc (Odoo >= 10) or
+                      ~/.openerp_serverrc.
+    --log-level TEXT   Specify the logging level. Accepted values depend on the
+                      Odoo version, and include debug, info, warn, error.
+                      [default: warn]
+    --logfile FILE     Specify the log file.
+    --help             Show this message and exit.
+
 click-odoo-uninstall (stable)
 -----------------------------
 
@@ -302,7 +322,7 @@ Contributors:
 - Stéphane Bidoul (ACSONE_)
 - Thomas Binsfeld (ACSONE_)
 - Benjamin Willig (ACSONE_)
-- Jairo Llopis (Tecnativa_)
+- Jairo Llopis
 - Laurent Mignon (ACSONE_)
 - Lois Rilo (ForgeFlow_)
 - Dmitry Voronin

--- a/click_odoo_contrib/dropdb.py
+++ b/click_odoo_contrib/dropdb.py
@@ -2,8 +2,6 @@
 # Copyright 2018 ACSONE SA/NV (<http://acsone.eu>)
 # License LGPL-3.0 or later (http://www.gnu.org/licenses/lgpl.html).
 
-import os
-
 import click
 import click_odoo
 from click_odoo import odoo
@@ -29,15 +27,6 @@ def main(env, dbname, if_exists=False):
         else:
             raise click.ClickException(msg)
     with db_management_enabled():
-        # Work around odoo.service.db.list_dbs() not finding the database
-        # when postgres connection info is passed as PG* environment
-        # variables.
-        if odoo.release.version_info < (12, 0):
-            for v in ("host", "port", "user", "password"):
-                odoov = "db_" + v.lower()
-                pgv = "PG" + v.upper()
-                if not odoo.tools.config[odoov] and pgv in os.environ:
-                    odoo.tools.config[odoov] = os.environ[pgv]
         odoo.service.db.exp_drop(dbname)
 
 

--- a/click_odoo_contrib/listdb.py
+++ b/click_odoo_contrib/listdb.py
@@ -1,0 +1,28 @@
+#!/usr/bin/env python
+# Copyright 2023 Moduon (https://www.moduon.team/)
+# License LGPL-3.0 or later (http://www.gnu.org/licenses/lgpl.html).
+
+import click
+import click_odoo
+from click_odoo import odoo
+
+from ._dbutils import db_management_enabled
+
+
+@click.command()
+@click_odoo.env_options(
+    default_log_level="warn", with_database=False, with_rollback=False
+)
+def main(env):
+    """List Odoo databases."""
+    with db_management_enabled():
+        all_dbs = odoo.service.db.list_dbs()
+        bad_dbs = odoo.service.db.list_db_incompatible(all_dbs)
+        good_dbs = set(all_dbs) - set(bad_dbs)
+        for db in sorted(good_dbs):
+            print(db)
+    odoo.sql_db.close_all()
+
+
+if __name__ == "__main__":  # pragma: no cover
+    main()

--- a/setup.py
+++ b/setup.py
@@ -50,6 +50,7 @@ setup(
         click-odoo-copydb=click_odoo_contrib.copydb:main
         click-odoo-dropdb=click_odoo_contrib.dropdb:main
         click-odoo-initdb=click_odoo_contrib.initdb:main
+        click-odoo-listdb=click_odoo_contrib.listdb:main
         click-odoo-backupdb=click_odoo_contrib.backupdb:main
         click-odoo-restoredb=click_odoo_contrib.restoredb:main
         click-odoo-makepot=click_odoo_contrib.makepot:main

--- a/tests/test_listdb.py
+++ b/tests/test_listdb.py
@@ -1,0 +1,17 @@
+# Copyright 2023 Moduon (https://www.moduon.team/)
+# License LGPL-3.0 or later (http://www.gnu.org/licenses/lgpl.html).
+import subprocess
+
+from click.testing import CliRunner
+
+from click_odoo_contrib.listdb import main
+
+
+def test_listdb(odoodb):
+    """Test that it only lists odoo-ready databases."""
+    try:
+        subprocess.check_call(["createdb", f"{odoodb}-not-odoo"])
+        result = CliRunner().invoke(main)
+        assert result.stdout.strip() == odoodb
+    finally:
+        subprocess.check_call(["dropdb", f"{odoodb}-not-odoo"])

--- a/tests/test_restoredb.py
+++ b/tests/test_restoredb.py
@@ -26,6 +26,7 @@ def _createdb(dbname):
 
 
 def _dropdb(dbname):
+    odoo.sql_db.close_all()
     subprocess.check_call(["dropdb", "--if-exists", dbname])
 
 


### PR DESCRIPTION
Getting DBs for Odoo is tricky:

1. Postgres must be running.
2. Odoo must be available.
3. Database must exist.
4. Some basic tables such as `ir_module_module` must exist.

Some scripts in this repo operate on just one database. But what if you don't know the DB name in advance? You need a way to get them.

With this new script, you can do now:

```shell
click-odoo-listdb | grep --invert-match cache | xargs click-odoo-update -d
```

@moduon MT-1075