### PR TITLE
[FIX] addons_analyse.py: compatibility with python3

### DIFF
--- a/click_odoo_contrib/addons_analyse.py
+++ b/click_odoo_contrib/addons_analyse.py
@@ -59,6 +59,8 @@ def _get_addon_base_info(module):
 
 def _addons_info_to_rows(addons_info):
     info_values = addons_info.values()
+    if not isinstance(info_values, list):
+        info_values = list(info_values)
     info_values.sort(key=lambda a: (a["author"], a["name"]))
     return info_values
 


### PR DESCRIPTION
In _addons_info_to_rows an error occurred with Python3 because values() method is not returning a list anymore, but a view object