### PR TITLE
Remove the click-odoo-upgrade entry point

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -45,7 +45,6 @@ setup(
     entry_points="""
         [console_scripts]
         click-odoo-uninstall=click_odoo_contrib.uninstall:main
-        click-odoo-upgrade=click_odoo_contrib.upgrade:main
         click-odoo-update=click_odoo_contrib.update:main
         click-odoo-copydb=click_odoo_contrib.copydb:main
         click-odoo-dropdb=click_odoo_contrib.dropdb:main


### PR DESCRIPTION
The script does not exist and was deprecated quite some time ago.