### PR TITLE
[FIX] click-odoo-update : avoid update mode when there are no module to update.

### DIFF
--- a/click_odoo_contrib/update.py
+++ b/click_odoo_contrib/update.py
@@ -240,6 +240,9 @@ def _update_db_nolock(
         odoo.tools.config["update"] = {}
         _logger.info("List-only selected, update is not performed.")
         return
+    if not to_update:
+        _logger.info("No module needs updating, update is not performed.")
+        return
     if i18n_overwrite:
         odoo.tools.config["overwrite_existing_translations"] = True
     odoo.modules.registry.Registry.new(database, update_module=True)

--- a/newsfragments/144.feature
+++ b/newsfragments/144.feature
@@ -1,0 +1,1 @@
+click-odoo-update : Do not run/update Odoo when no module needs updating.


### PR DESCRIPTION
Hello,

I ran in really strange bug in Odoo 14 when playing click-odoo-update on database with no module to upgrade.
I guess there is no need to do it when no modules have changed, what do you think @sbidoul ?

Here the bug I ran in and how to reproduce it. I did only test with version 14.
1) Create a new database with sale module.
2) Check the res.users group view (`base.user_groups_view`), you should have something like that to display the sales 3 group level  : 
```
    <group col="2" string="Sales">
      <newline/>
      <field name="sel_groups_20_21_22" attrs="{'readonly': [('sel_groups_1_9_10', '!=', 1)]}"/>
      <newline/>
```

3) Run click-odoo-update twice, on first call, it will update all and create the hash for the modules, on second call, it won't update any module.
Then, check the `base.user_groups_view` again. You'll have something like : 
```
      <separator string="Sales" colspan="4"/>
    <field name="in_group_22" attrs="{'readonly': [('sel_groups_1_9_10', '!=', 1)]}"/>
    <field name="in_group_21" attrs="{'readonly': [('sel_groups_1_9_10', '!=', 1)]}"/>
    <field name="in_group_20" attrs="{'readonly': [('sel_groups_1_9_10', '!=', 1)]}"/>
```
Which is incorrect, as these 3 sale's groups should be displayed as a Selection field, like in step 2)
The displaying is actually not a big issue, but this create an instable view, which may block the update of other modules inheriting the res.users form view.

I am not exactly sure of why there is this behavior. What I saw is that, when running click-odoo-update with no module to update, when Odoo try to update the `base.user_groups_view` and compute the `res.group` 's `trans_implied_ids` field, the recursive attribute of this field is not set, leading to a wrong computation, leading to a wrong update on the view.
This does not happen when we actually update any module.


Note, the bug I described is not really related with click-odoo-update, because the same would happen running the command : 
`odoo -u module_that_does_not_exist`
But still, it seems like an easy fix/improvement not to launch Odoo with update mode when there is no need.