### PR TITLE
Load server wide modules for initdb and update

### DIFF
--- a/click_odoo_contrib/initdb.py
+++ b/click_odoo_contrib/initdb.py
@@ -64,6 +64,7 @@ def odoo_createdb(dbname, demo, module_names, force_db_storage):
         odoo.service.db._create_empty_database(dbname)
         odoo.tools.config["init"] = dict.fromkeys(module_names, 1)
         odoo.tools.config["without_demo"] = not demo
+        odoo.service.server.load_server_wide_modules()
         odoo.modules.registry.Registry.new(dbname, force_demo=demo, update_module=True)
         _logger.info(click.style(f"Created new Odoo database {dbname}.", fg="green"))
         with odoo.sql_db.db_connect(dbname).cursor() as cr:

--- a/click_odoo_contrib/update.py
+++ b/click_odoo_contrib/update.py
@@ -245,6 +245,7 @@ def _update_db_nolock(
         return
     if i18n_overwrite:
         odoo.tools.config["overwrite_existing_translations"] = True
+    odoo.service.server.load_server_wide_modules()
     odoo.modules.registry.Registry.new(database, update_module=True)
     if watcher and watcher.aborted:
         # If you get here, the updating session has been terminated and it


### PR DESCRIPTION
Following https://github.com/acsone/click-odoo/pull/56 also load server wide modules in initdb and update environments.