### PR TITLE
[FIX] initdb - with_demo is the config name but in the Registry.__init__ the name is new_db_demo

### DIFF
--- a/click_odoo_contrib/initdb.py
+++ b/click_odoo_contrib/initdb.py
@@ -65,10 +65,14 @@ def odoo_createdb(dbname, demo, module_names, force_db_storage):
         odoo.tools.config["init"] = dict.fromkeys(module_names, 1)
         if odoo.release.version_info >= (19, 0):
             odoo.tools.config["with_demo"] = demo
-            odoo.modules.registry.Registry.new(dbname, new_db_demo=demo, update_module=True)
+            odoo.modules.registry.Registry.new(
+                dbname, new_db_demo=demo, update_module=True
+            )
         else:
             odoo.tools.config["without_demo"] = not demo
-            odoo.modules.registry.Registry.new(dbname, force_demo=demo, update_module=True)
+            odoo.modules.registry.Registry.new(
+                dbname, force_demo=demo, update_module=True
+            )
         _logger.info(click.style(f"Created new Odoo database {dbname}.", fg="green"))
         with odoo.sql_db.db_connect(dbname).cursor() as cr:
             _save_installed_checksums(cr)

--- a/click_odoo_contrib/initdb.py
+++ b/click_odoo_contrib/initdb.py
@@ -63,8 +63,12 @@ def odoo_createdb(dbname, demo, module_names, force_db_storage):
     with _patch_ir_attachment_store(force_db_storage):
         odoo.service.db._create_empty_database(dbname)
         odoo.tools.config["init"] = dict.fromkeys(module_names, 1)
-        odoo.tools.config["without_demo"] = not demo
-        odoo.modules.registry.Registry.new(dbname, force_demo=demo, update_module=True)
+        if odoo.release.version_info >= (19, 0):
+            odoo.tools.config["with_demo"] = demo
+            odoo.modules.registry.Registry.new(dbname, new_db_demo=demo, update_module=True)
+        else:
+            odoo.tools.config["without_demo"] = not demo
+            odoo.modules.registry.Registry.new(dbname, force_demo=demo, update_module=True)
         _logger.info(click.style(f"Created new Odoo database {dbname}.", fg="green"))
         with odoo.sql_db.db_connect(dbname).cursor() as cr:
             _save_installed_checksums(cr)


### PR DESCRIPTION
In odoo 19.0, the new method of Registry was refactored (https://github.com/odoo/odoo/commit/612b1acee34dad957b7b9f299c4d8118e7afcc77)

Now there is a new_db_demo parameter to install (or not) demo data. If it is set to None, its checks if the config contains a with_demo parameter.

cc @sbidoul 

fixes #166