### PR TITLE
[FIX] makepot.py - Update the pot file only if odoo generates content

### DIFF
--- a/click_odoo_contrib/makepot.py
+++ b/click_odoo_contrib/makepot.py
@@ -49,11 +49,12 @@ def export_pot(
     files_to_commit = set()
 
     files_to_commit.add(pot_filepath)
-    with open(pot_filepath, "w", encoding="utf-8") as pot_file:
-        file_content = base64.b64decode(lang_export.data).decode("utf-8")
-        for pattern in LINE_PATTERNS_TO_REMOVE:
-            file_content = re.sub(pattern, "", file_content, flags=re.MULTILINE)
-        pot_file.write(file_content)
+    if lang_export.data:
+        with open(pot_filepath, "w", encoding="utf-8") as pot_file:
+            file_content = base64.b64decode(lang_export.data).decode("utf-8")
+            for pattern in LINE_PATTERNS_TO_REMOVE:
+                file_content = re.sub(pattern, "", file_content, flags=re.MULTILINE)
+            pot_file.write(file_content)
 
     invalid_po = 0
     for lang_filename in os.listdir(i18n_path):

--- a/newsfragments/421.bugfix
+++ b/newsfragments/421.bugfix
@@ -1,0 +1,1 @@
+click-odoo-makepot: support modules with no translatable terms in Odoo 19.

--- a/tests/scripts/install_odoo.py
+++ b/tests/scripts/install_odoo.py
@@ -68,6 +68,16 @@ def install_odoo():
                 "setuptools<58",
             ]
         )
+    if odoo_branch in ["14.0", "15.0", "16.0", "17.0"]:
+        # Odoo < 18 needs pkg_resources, to make sure setuptools (which provides
+        # pkg_resources) is installed in the venv
+        subprocess.check_call(
+            [
+                "pip",
+                "install",
+                "setuptools",
+            ]
+        )
     with odoo_requirements(odoo_branch) as requirements:
         subprocess.check_call(["pip", "install", *requirements])
     odoo_install_cmd = ["pip", "install", "-e", odoo_dir]

--- a/tests/test_makepot.py
+++ b/tests/test_makepot.py
@@ -5,7 +5,10 @@ import os
 import shutil
 import subprocess
 
+import pytest
+
 import click_odoo
+from click_odoo import odoo
 from .compat import CliRunner
 
 from click_odoo_contrib.makepot import main
@@ -367,6 +370,9 @@ def test_makepot_detect_bad_po(odoodb, odoocfg, capfd):
     assert "msgmerge: found 1 fatal error" in capture.err
 
 
+@pytest.mark.skipif(
+    odoo.release.version_info < (19, 0), reason="Only Odoo 19 generates empty .pot"
+)
 def test_makepot_no_translations(odoodb, odoocfg, tmp_path):
     # create a test addon without translations
     addon_name = "addon_test_makepot_no_trans"

--- a/tests/test_makepot.py
+++ b/tests/test_makepot.py
@@ -365,3 +365,53 @@ def test_makepot_detect_bad_po(odoodb, odoocfg, capfd):
     capture = capfd.readouterr()
     assert "duplicate message definition" in capture.err
     assert "msgmerge: found 1 fatal error" in capture.err
+
+
+def test_makepot_no_translations(odoodb, odoocfg, tmp_path):
+    # create a test addon without translations
+    addon_name = "addon_test_makepot_no_trans"
+    addons_dir = tmp_path / "addons"
+    addon_dir = addons_dir / addon_name
+    i18n_dir = addon_dir / "i18n"
+    pot_file = i18n_dir / (addon_name + ".pot")
+    addon_dir.mkdir(parents=True)
+    addon_dir.joinpath("__init__.py").write_text("")
+    addon_dir.joinpath("__manifest__.py").write_text("{'name': 'test addon'}")
+    # install test addon
+    subprocess.check_call(
+        [
+            click_odoo.odoo_bin,
+            "-d",
+            odoodb,
+            "-c",
+            str(odoocfg),
+            "-i",
+            addon_name,
+            "--addons-path",
+            addons_dir,
+            "--stop-after-init",
+        ]
+    )
+    # export translations and check that no i18n content is created
+    result = CliRunner().invoke(
+        main, ["-d", odoodb, "-c", str(odoocfg), "--addons-dir", addons_dir]
+    )
+    assert result.exit_code == 0
+    assert not list(i18n_dir.iterdir())
+    # create a .pot file and chech that it is removed
+    pot_file.touch()
+    result = CliRunner().invoke(
+        main, ["-d", odoodb, "-c", str(odoocfg), "--addons-dir", addons_dir]
+    )
+    assert result.exit_code == 0
+    assert not pot_file.exists()
+    assert not list(i18n_dir.iterdir())
+    # create a .po file and check that an empty .pot file is created
+    po_file = i18n_dir / "fr.po"
+    po_file.touch()
+    result = CliRunner().invoke(
+        main, ["-d", odoodb, "-c", str(odoocfg), "--addons-dir", addons_dir]
+    )
+    assert result.exit_code == 0
+    assert pot_file.exists()
+    assert pot_file.read_text() == "# No translations.\n"


### PR DESCRIPTION
In odoo 19 if there is no translatable terms found, instead of creating an empty pot file with an empty line, Odoo return an Empty buffer.

Odoo 18:

```
# Translation of Odoo Server.
# This file contains the translation of the following modules:
#
msgid ""
msgstr ""
"Project-Id-Version: Odoo Server 18.0+e\n"
"Report-Msgid-Bugs-To: \n"
"Last-Translator: \n"
"Language-Team: \n"
"MIME-Version: 1.0\n"
"Content-Type: text/plain; charset=UTF-8\n"
"Content-Transfer-Encoding: \n"
"Plural-Forms: \n"
```


Odoo 19:
<img width="1099" height="745" alt="Capture d’écran du 2025-10-09 08-02-08" src="https://github.com/user-attachments/assets/cf4a9841-dda0-40be-ac6c-7749c7e1dfb8" />

