### PR TITLE
[IMP] initdb: add language, country, username and password

### DIFF
--- a/click_odoo_contrib/initdb.py
+++ b/click_odoo_contrib/initdb.py
@@ -108,13 +108,11 @@ def odoo_createdb(
                     [("code", "ilike", country)], limit=1
                 )
                 if chosen_country:
-                    env["res.company"].browse(1).write(
-                        {
-                            "country_id": chosen_country.id,
-                            "currency_id": chosen_country.currency_id.id,
-                        }
-                    )
-                    timezones = country_timezones.get(country.upper(), [])
+                    env["res.company"].browse(1).write({
+                        "country_id": chosen_country.id,
+                        "currency_id": chosen_country.currency_id.id,
+                    })
+                    timezones = country_timezones.get(country, [])
                     if len(timezones) == 1:
                         env["res.users"].search([]).write({"tz": timezones[0]})
 

--- a/click_odoo_contrib/initdb.py
+++ b/click_odoo_contrib/initdb.py
@@ -108,10 +108,12 @@ def odoo_createdb(
                     [("code", "ilike", country)], limit=1
                 )
                 if chosen_country:
-                    env["res.company"].browse(1).write({
-                        "country_id": chosen_country.id,
-                        "currency_id": chosen_country.currency_id.id,
-                    })
+                    env["res.company"].browse(1).write(
+                        {
+                            "country_id": chosen_country.id,
+                            "currency_id": chosen_country.currency_id.id,
+                        }
+                    )
                     timezones = country_timezones.get(country, [])
                     if len(timezones) == 1:
                         env["res.users"].search([]).write({"tz": timezones[0]})

--- a/click_odoo_contrib/initdb.py
+++ b/click_odoo_contrib/initdb.py
@@ -75,9 +75,9 @@ def odoo_createdb(
 ):
     with _patch_ir_attachment_store(force_db_storage):
         if not exists:
-            odoo.service.db._create_empty_database(dbname)
             if language:
                 odoo.tools.config["load_language"] = language
+            odoo.service.db._create_empty_database(dbname)
         if odoo.release.version_info >= (19, 0):
             odoo.tools.config["with_demo"] = demo
             registry = odoo.modules.registry.Registry.new(

--- a/click_odoo_contrib/initdb.py
+++ b/click_odoo_contrib/initdb.py
@@ -469,26 +469,22 @@ class DbCache:
 )
 @click.option(
     "--language",
-    "-l",
     default=None,
     help="Default language for the database (e.g., en_US, fr_FR).",
 )
 @click.option(
     "--country",
-    "-c",
     default=None,
     help="Country code to set on the main company (e.g., US, FR, BE).",
 )
 @click.option(
     "--username",
-    "-u",
     default="admin",
     show_default=True,
     help="Admin username for the database.",
 )
 @click.option(
     "--password",
-    "-p",
     default="admin",
     show_default=True,
     help="Admin password for the database.",


### PR DESCRIPTION
I know it exists https://github.com/acsone/click-odoo-contrib/pull/101, but I think a cached version is necessary.

This implementation has these objectives:
1. Doesn't break old caches because new params aren't computed on the hash by default, only when using.
2. Uses a similar focus to [Odoo's oficial initialization](https://github.com/odoo/odoo/blob/a175fdffaa1fd5179e1f64f1089bdc4c5b2d9d87/odoo/service/db.py#L67-L102).
3. Has to work with older and newer versions.

I know that on Odoo 19 this script shouldn't be necessary, just for cache, but I think this should be important for older versions.

I'm going to start testing it on `18.0`, but at the moment should be working with the first commit. Will be working on this PR.