### PR TITLE
Extension for Development

### DIFF
--- a/click_odoo_contrib/_dbutils.py
+++ b/click_odoo_contrib/_dbutils.py
@@ -1,4 +1,5 @@
 # Copyright 2018 ACSONE SA/NV (<http://acsone.eu>)
+# Copyright 2026 Michael Tietz (MT Software) <mtietz@mt-software.de>
 # License LGPL-3.0 or later (http://www.gnu.org/licenses/lgpl.html).
 
 import hashlib
@@ -108,3 +109,14 @@ def reset_config_parameters(dbname):
 
         """
         )
+
+
+def get_dev_demo_dbname():
+    environ = os.environ
+    dev_mode_env_name = "DEV_MODE"
+    if odoo.release.version_info >= (19, 0):
+        dev_mode_env_name = "ODOO_DEV"
+    if dev_mode_env_name in environ:
+        click_odoo_demo_dbname_env_name = "CLICK_ODOO_DEV_DEMO_DBNAME"
+        if click_odoo_demo_dbname_env_name in environ:
+            return environ[click_odoo_demo_dbname_env_name]

--- a/click_odoo_contrib/dropdb.py
+++ b/click_odoo_contrib/dropdb.py
@@ -1,12 +1,13 @@
 #!/usr/bin/env python
 # Copyright 2018 ACSONE SA/NV (<http://acsone.eu>)
+# Copyright 2026 Michael Tietz (MT Software) <mtietz@mt-software.de>
 # License LGPL-3.0 or later (http://www.gnu.org/licenses/lgpl.html).
 
 import click
 import click_odoo
 from click_odoo import odoo
 
-from ._dbutils import db_exists, db_management_enabled
+from ._dbutils import db_exists, db_management_enabled, get_dev_demo_dbname
 
 
 @click.command()
@@ -16,9 +17,13 @@ from ._dbutils import db_exists, db_management_enabled
 @click.option(
     "--if-exists", is_flag=True, help="Don't report error if database doesn't exist."
 )
-@click.argument("dbname", nargs=1)
-def main(env, dbname, if_exists=False):
+@click.argument("dbname", nargs=1, required=False)
+def main(env, dbname=None, if_exists=False):
     """Drop an Odoo database and associated file store."""
+    if not dbname:
+        dbname = get_dev_demo_dbname()
+    if not dbname:
+        raise click.ClickException("No dbname provided")
     if not db_exists(dbname):
         msg = "Database does not exist: {}".format(dbname)
         if if_exists:

--- a/click_odoo_contrib/dropdb.py
+++ b/click_odoo_contrib/dropdb.py
@@ -1,27 +1,16 @@
 #!/usr/bin/env python
 # Copyright 2018 ACSONE SA/NV (<http://acsone.eu>)
-# Copyright 2026 Michael Tietz (MT Software) <mtietz@mt-software.de>
 # License LGPL-3.0 or later (http://www.gnu.org/licenses/lgpl.html).
 
 import click
 import click_odoo
 from click_odoo import odoo
 
-from ._dbutils import db_exists, db_management_enabled, get_dev_demo_dbname
+from ._dbutils import db_exists, db_management_enabled
 
 
-@click.command()
-@click_odoo.env_options(
-    default_log_level="warn", with_database=False, with_rollback=False
-)
-@click.option(
-    "--if-exists", is_flag=True, help="Don't report error if database doesn't exist."
-)
-@click.argument("dbname", nargs=1, required=False)
-def main(env, dbname=None, if_exists=False):
+def _drop_db(env, dbname, if_exists=False):
     """Drop an Odoo database and associated file store."""
-    if not dbname:
-        dbname = get_dev_demo_dbname()
     if not dbname:
         raise click.ClickException("No dbname provided")
     if not db_exists(dbname):
@@ -33,6 +22,18 @@ def main(env, dbname=None, if_exists=False):
             raise click.ClickException(msg)
     with db_management_enabled():
         odoo.service.db.exp_drop(dbname)
+
+
+@click.command()
+@click_odoo.env_options(
+    default_log_level="warn", with_database=False, with_rollback=False
+)
+@click.option(
+    "--if-exists", is_flag=True, help="Don't report error if database doesn't exist."
+)
+@click.argument("dbname", nargs=1)
+def main(env, dbname, if_exists=False):
+    _drop_db(env, dbname, if_exists)
 
 
 if __name__ == "__main__":  # pragma: no cover

--- a/click_odoo_contrib/initaddonhashes.py
+++ b/click_odoo_contrib/initaddonhashes.py
@@ -1,0 +1,39 @@
+#!/usr/bin/env python
+# Copyright 2024 Michael Tietz (MT Software) <mtietz@mt-software.de>
+# License LGPL-3.0 or later (http://www.gnu.org/licenses/lgpl.html).
+import click
+import click_odoo
+
+from .update import _get_ignore_addons, _save_installed_checksums
+
+
+@click.command()
+@click_odoo.env_options()
+@click.option(
+    "--ignore-addons",
+    help=(
+        "A comma-separated list of addons to ignore. "
+        "These will not be updated if their checksum has changed. "
+        "Use with care."
+    ),
+)
+@click.option(
+    "--ignore-core-addons",
+    is_flag=True,
+    help=(
+        "If this option is set, Odoo CE and EE addons are not updated. "
+        "This is normally safe, due the Odoo stable policy."
+    ),
+)
+def main(
+    env,
+    ignore_addons,
+    ignore_core_addons,
+):
+    """Initialise Hash Values of installed Addons"""
+    ignore_addons = _get_ignore_addons(ignore_addons, ignore_core_addons)
+    _save_installed_checksums(env.cr, ignore_addons)
+
+
+if __name__ == "__main__":  # pragma: no cover
+    main()

--- a/click_odoo_contrib/initdb.py
+++ b/click_odoo_contrib/initdb.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python
 # Copyright 2018 ACSONE SA/NV (<http://acsone.eu>)
+# Copyright 2026 Michael Tietz (MT Software) <mtietz@mt-software.de>
 # License LGPL-3.0 or later (http://www.gnu.org/licenses/lgpl.html).
 import contextlib
 import hashlib
@@ -13,7 +14,7 @@ import click
 import click_odoo
 from click_odoo import odoo
 
-from ._dbutils import advisory_lock, db_exists, pg_connect
+from ._dbutils import advisory_lock, db_exists, pg_connect, get_dev_demo_dbname
 from .manifest import expand_dependencies
 from .update import _save_installed_checksums
 
@@ -369,6 +370,8 @@ def main(
     checksum of modules provided with the -m option, including their
     dependencies and corresponding auto_install modules.
     """
+    if not new_database:
+        new_database = get_dev_demo_dbname()
     if new_database:
         check_dbname(new_database)
     if unless_exists and db_exists(new_database):

--- a/click_odoo_contrib/initdb.py
+++ b/click_odoo_contrib/initdb.py
@@ -1,6 +1,5 @@
 #!/usr/bin/env python
 # Copyright 2018 ACSONE SA/NV (<http://acsone.eu>)
-# Copyright 2026 Michael Tietz (MT Software) <mtietz@mt-software.de>
 # License LGPL-3.0 or later (http://www.gnu.org/licenses/lgpl.html).
 import contextlib
 import hashlib
@@ -14,7 +13,7 @@ import click
 import click_odoo
 from click_odoo import odoo
 
-from ._dbutils import advisory_lock, db_exists, pg_connect, get_dev_demo_dbname
+from ._dbutils import advisory_lock, db_exists, pg_connect
 from .manifest import expand_dependencies
 from .update import _save_installed_checksums
 
@@ -281,6 +280,65 @@ class DbCache:
                 self._drop_db(datname)
 
 
+def _init_db(
+    env,
+    new_database=None,
+    modules="base",
+    demo=True,
+    cache=True,
+    cache_prefix="cache",
+    cache_max_age=30,
+    cache_max_size=5,
+    unless_exists=False,
+):
+    """Create an Odoo database with pre-installed modules.
+
+    Almost like standard Odoo does with the -i option,
+    except this script manages a cache of database templates with
+    the exact same addons installed. This is particularly useful to
+    save time when initializing test databases.
+
+    Cached templates are identified by computing a sha1
+    checksum of modules provided with the -m option, including their
+    dependencies and corresponding auto_install modules.
+    """
+    if new_database:
+        check_dbname(new_database)
+    if unless_exists and db_exists(new_database):
+        msg = "Database already exists: {}".format(new_database)
+        click.echo(click.style(msg, fg="yellow"))
+        return
+    module_names = [m.strip() for m in modules.split(",")]
+    if not cache:
+        if new_database:
+            odoo_createdb(new_database, demo, module_names, False)
+        else:
+            _logger.info(
+                "Cache disabled and no new database name provided. " "Nothing to do."
+            )
+    else:
+        with pg_connect() as pgcr:
+            dbcache = DbCache(cache_prefix, pgcr)
+            if new_database:
+                hashsum = addons_hash(module_names, demo)
+                if dbcache.create(new_database, hashsum):
+                    _logger.info(
+                        click.style(
+                            "Found matching database template! ✨ 🍰 ✨",
+                            fg="green",
+                            bold=True,
+                        )
+                    )
+                    refresh_module_list(new_database)
+                else:
+                    odoo_createdb(new_database, demo, module_names, True)
+                    dbcache.add(new_database, hashsum)
+            if cache_max_size >= 0:
+                dbcache.trim_size(cache_max_size)
+            if cache_max_age >= 0:
+                dbcache.trim_age(timedelta(days=cache_max_age))
+
+
 @click.command()
 @click_odoo.env_options(
     default_log_level="warn",
@@ -359,54 +417,17 @@ def main(
     cache_max_size,
     unless_exists,
 ):
-    """Create an Odoo database with pre-installed modules.
-
-    Almost like standard Odoo does with the -i option,
-    except this script manages a cache of database templates with
-    the exact same addons installed. This is particularly useful to
-    save time when initializing test databases.
-
-    Cached templates are identified by computing a sha1
-    checksum of modules provided with the -m option, including their
-    dependencies and corresponding auto_install modules.
-    """
-    if not new_database:
-        new_database = get_dev_demo_dbname()
-    if new_database:
-        check_dbname(new_database)
-    if unless_exists and db_exists(new_database):
-        msg = "Database already exists: {}".format(new_database)
-        click.echo(click.style(msg, fg="yellow"))
-        return
-    module_names = [m.strip() for m in modules.split(",")]
-    if not cache:
-        if new_database:
-            odoo_createdb(new_database, demo, module_names, False)
-        else:
-            _logger.info(
-                "Cache disabled and no new database name provided. " "Nothing to do."
-            )
-    else:
-        with pg_connect() as pgcr:
-            dbcache = DbCache(cache_prefix, pgcr)
-            if new_database:
-                hashsum = addons_hash(module_names, demo)
-                if dbcache.create(new_database, hashsum):
-                    _logger.info(
-                        click.style(
-                            "Found matching database template! ✨ 🍰 ✨",
-                            fg="green",
-                            bold=True,
-                        )
-                    )
-                    refresh_module_list(new_database)
-                else:
-                    odoo_createdb(new_database, demo, module_names, True)
-                    dbcache.add(new_database, hashsum)
-            if cache_max_size >= 0:
-                dbcache.trim_size(cache_max_size)
-            if cache_max_age >= 0:
-                dbcache.trim_age(timedelta(days=cache_max_age))
+    _init_db(
+        env,
+        new_database,
+        modules,
+        demo,
+        cache,
+        cache_prefix,
+        cache_max_age,
+        cache_max_size,
+        unless_exists,
+    )
 
 
 if __name__ == "__main__":  # pragma: no cover

--- a/click_odoo_contrib/manifest.py
+++ b/click_odoo_contrib/manifest.py
@@ -28,12 +28,16 @@ def parse_manifest(s):
     return ast.literal_eval(s)
 
 
+def _read_manifest(manifest_path):
+    with open(manifest_path) as mf:
+        return parse_manifest(mf.read())
+
+
 def read_manifest(addon_dir):
     manifest_path = get_manifest_path(addon_dir)
     if not manifest_path:
         raise NoManifestFound("no Odoo manifest found in %s" % addon_dir)
-    with open(manifest_path) as mf:
-        return parse_manifest(mf.read())
+    return _read_manifest(manifest_path)
 
 
 def find_addons(addons_dir, installable_only=True):
@@ -47,6 +51,22 @@ def find_addons(addons_dir, installable_only=True):
         if installable_only and not manifest.get("installable", True):
             continue
         yield addon_name, addon_dir, manifest
+
+
+def find_addons_bidir(addons_dir, installable_only=True):
+    addons_list = list(find_addons(addons_dir, installable_only=True))
+    if addons_list:
+        return addons_list
+    addons_dir_path = Path(addons_dir).absolute()
+    manifest_path = None
+    while not manifest_path and addons_dir_path.name:
+        manifest_path = get_manifest_path(addons_dir)
+        if not manifest_path:
+            addons_dir_path = addons_dir_path.parent
+    if manifest_path:
+        return [
+            (addons_dir_path.name, str(addons_dir_path), _read_manifest(manifest_path))
+        ]
 
 
 def expand_dependencies(module_names, include_auto_install=False, include_active=False):

--- a/click_odoo_contrib/resetdemo.py
+++ b/click_odoo_contrib/resetdemo.py
@@ -7,6 +7,7 @@ import click_odoo
 from ._dbutils import get_dev_demo_dbname
 from .dropdb import _drop_db
 from .initdb import _init_db
+from .manifest import find_addons_bidir
 
 
 @click.command()
@@ -32,6 +33,9 @@ def main(
         dbname = get_dev_demo_dbname()
     if not dbname:
         raise click.ClickException("No dbname provided")
+    if modules == ".":
+        addons = find_addons_bidir(modules)
+        modules = ",".join(addon[0] for addon in addons)
 
     _drop_db(env, dbname)
     _init_db(

--- a/click_odoo_contrib/resetdemo.py
+++ b/click_odoo_contrib/resetdemo.py
@@ -5,7 +5,7 @@ import click
 import click_odoo
 
 from ._dbutils import get_dev_demo_dbname
-from .drobdb import _drop_db
+from .dropdb import _drop_db
 from .initdb import _init_db
 
 

--- a/click_odoo_contrib/resetdemo.py
+++ b/click_odoo_contrib/resetdemo.py
@@ -1,0 +1,45 @@
+#!/usr/bin/env python
+# Copyright 2026 Michael Tietz (MT Software) <mtietz@mt-software.de>
+# License LGPL-3.0 or later (http://www.gnu.org/licenses/lgpl.html).
+import click
+import click_odoo
+
+from ._dbutils import get_dev_demo_dbname
+from .drobdb import _drop_db
+from .initdb import _init_db
+
+
+@click.command()
+@click_odoo.env_options(
+    default_log_level="warn",
+    with_database=False,
+    with_rollback=False,
+    with_addons_path=True,
+)
+@click.option(
+    "--dbname",
+    "-d",
+    required=False,
+    help="Name of database to drop and to create",
+)
+@click.argument("modules", nargs=1, required=False, default="base")
+def main(
+    env,
+    dbname,
+    modules,
+):
+    if not dbname:
+        dbname = get_dev_demo_dbname()
+    if not dbname:
+        raise click.ClickException("No dbname provided")
+
+    _drop_db(env, dbname)
+    _init_db(
+        env,
+        dbname,
+        modules,
+    )
+
+
+if __name__ == "__main__":  # pragma: no cover
+    main()

--- a/click_odoo_contrib/update.py
+++ b/click_odoo_contrib/update.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python
 # Copyright 2018 ACSONE SA/NV (<http://acsone.eu>)
+# Copyright 2024 Michael Tietz (MT Software) <mtietz@mt-software.de>
 # License LGPL-3.0 or later (http://www.gnu.org/licenses/lgpl.html).
 
 import json
@@ -278,6 +279,15 @@ def _update_db(
         )
 
 
+def _get_ignore_addons(ignore_addons_str=None, ignore_core_addons=None):
+    ignore_addons = set()
+    if ignore_addons_str:
+        ignore_addons.update(ignore_addons_str.strip().split(","))
+    if ignore_core_addons:
+        ignore_addons.update(get_core_addons(OdooSeries(odoo.release.series)))
+    return ignore_addons
+
+
 @contextmanager
 def OdooEnvironmentWithUpdate(database, ctx, **kwargs):
     # Watch for database locks while Odoo updates
@@ -285,11 +295,9 @@ def OdooEnvironmentWithUpdate(database, ctx, **kwargs):
     if ctx.params["watcher_max_seconds"] > 0:
         watcher = DbLockWatcher(database, ctx.params["watcher_max_seconds"])
         watcher.start()
-    ignore_addons = set()
-    if ctx.params["ignore_addons"]:
-        ignore_addons.update(ctx.params["ignore_addons"].strip().split(","))
-    if ctx.params["ignore_core_addons"]:
-        ignore_addons.update(get_core_addons(OdooSeries(odoo.release.series)))
+    ignore_addons = _get_ignore_addons(
+        ctx.params["ignore_addons"], ctx.params["ignore_core_addons"]
+    )
     if ignore_addons and ctx.params["update_all"]:
         raise click.ClickException(
             "--update-all and --ignore(-core)-addons cannot be used together"

--- a/setup.py
+++ b/setup.py
@@ -54,5 +54,6 @@ setup(
         click-odoo-backupdb=click_odoo_contrib.backupdb:main
         click-odoo-restoredb=click_odoo_contrib.restoredb:main
         click-odoo-makepot=click_odoo_contrib.makepot:main
+        click-odoo-initaddonhashes=click_odoo_contrib.initaddonhashes:main
     """,
 )

--- a/setup.py
+++ b/setup.py
@@ -55,5 +55,6 @@ setup(
         click-odoo-restoredb=click_odoo_contrib.restoredb:main
         click-odoo-makepot=click_odoo_contrib.makepot:main
         click-odoo-initaddonhashes=click_odoo_contrib.initaddonhashes:main
+        click-odoo-resetdemo=click_odoo_contrib.resetdemo:main
     """,
 )


### PR DESCRIPTION
Get dbname for dropdb and initdb from environment. 
This allows to reset a demo database without passing dbname arguments.  