### PR TITLE
[FIX] initdb: scope cache operations to the current PostgreSQL user

### DIFF
--- a/click_odoo_contrib/initdb.py
+++ b/click_odoo_contrib/initdb.py
@@ -220,6 +220,7 @@ class DbCache:
             """
             SELECT datname FROM pg_database
             WHERE datname like %s
+              AND pg_catalog.pg_get_userbyid(datdba) = current_user
             ORDER BY datname DESC  -- MRU first
             """,
             (pattern,),
@@ -266,6 +267,7 @@ class DbCache:
                 """
                 SELECT count(*) FROM pg_database
                 WHERE datname like %s
+                  AND pg_catalog.pg_get_userbyid(datdba) = current_user
             """,
                 (pattern,),
             )
@@ -278,6 +280,7 @@ class DbCache:
                 """
                 SELECT datname FROM pg_database
                 WHERE datname like %s
+                  AND pg_catalog.pg_get_userbyid(datdba) = current_user
             """,
                 (pattern,),
             )
@@ -291,6 +294,7 @@ class DbCache:
                 """
                 SELECT datname FROM pg_database
                 WHERE datname like %s
+                  AND pg_catalog.pg_get_userbyid(datdba) = current_user
                 ORDER BY datname DESC
                 OFFSET %s
             """,
@@ -309,6 +313,7 @@ class DbCache:
                 """
                 SELECT datname FROM pg_database
                 WHERE datname like %s
+                  AND pg_catalog.pg_get_userbyid(datdba) = current_user
                   AND datname <= %s
                 ORDER BY datname DESC
             """,
@@ -357,9 +362,11 @@ class DbCache:
     show_default=True,
     help="Prefix to use when naming cache template databases "
     "(max 8 characters). CAUTION: all databases named like "
-    "{prefix}-____________-% will eventually be dropped "
-    "by the cache control mechanism, so choose the "
-    "prefix wisely.",
+    "{prefix}-____________-% and owned by the current PostgreSQL "
+    "user will eventually be dropped by the cache control mechanism. "
+    "In environments with multiple PostgreSQL users sharing the same "
+    "server, each user must use a distinct prefix to avoid name "
+    "collisions when caching the same module combination.",
 )
 @click.option(
     "--cache-max-age",


### PR DESCRIPTION
All pg_database queries in DbCache now filter by datdba = current_user, preventing cache templates owned by other PostgreSQL users from being consumed, renamed, or dropped.

Without this filter, in a multi-user setup sharing a single PostgreSQL server:
- trim_size/trim_age/purge could DROP databases belonging to other users
- _find_template could return another user's template, causing CREATE DATABASE to fail (non-superuser) or _touch to silently rename the other user's template (superuser)

The --cache-prefix help text is updated to document that each PostgreSQL user must use a distinct prefix to avoid template name collisions when caching the same module combination. Closes #84.