### PR TITLE
[IMP] click-odoo-update: Add --pre-update-scripts option to run pre-u…

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -320,7 +320,11 @@ click-odoo-update (stable)
                                  before updating the database. This is useful for
                                  performing custom pre-update tasks, before the Odoo
                                  update process starts. The scripts will be executed
-                                 in the order they are provided.
+                                 in the order they are provided. Note: these scripts
+                                 only run if at least one addon is actually updated;
+                                 if no addon checksum changed, click-odoo-update exits
+                                 early and the scripts are not executed. Use
+                                 --update-all to guarantee they always run.
     --help                       Show this message and exit.
 
 Useful links

--- a/README.rst
+++ b/README.rst
@@ -316,6 +316,11 @@ click-odoo-update (stable)
     --only-compute-hashes        Initialise hash values of installed addons.
                                  Use this when you are sure all your addons are up-to-date
                                  and you don't want to run `click-odoo-update --update-all`.
+    --pre-update-scripts PATHS   Comma-separated list of Python scripts to run
+                                 before updating the database. This is useful for
+                                 performing custom pre-update tasks, before the Odoo
+                                 update process starts. The scripts will be executed
+                                 in the order they are provided.
     --help                       Show this message and exit.
 
 Useful links

--- a/click_odoo_contrib/update.py
+++ b/click_odoo_contrib/update.py
@@ -224,7 +224,12 @@ def _update_db_nolock(
     watcher=None,
     list_only=False,
     ignore_addons=None,
+    pre_update_scripts=None,
 ):
+    if pre_update_scripts and odoo.release.version_info >= (16, 0):
+        odoo.tools.config["pre_upgrade_scripts"] = ",".join(
+            str(p) for p in pre_update_scripts
+        )
     if update_all:
         modules_to_update = ["base"]
     else:
@@ -261,19 +266,6 @@ def _update_db_nolock(
         _save_installed_checksums(cr, ignore_addons)
 
 
-def _run_pre_update_scripts(pre_update_scripts, cr):
-    if not pre_update_scripts:
-        return
-    from odoo.modules import migration
-
-    _logger.info("Running pre-update scripts...")
-    cr.execute("SELECT latest_version FROM ir_module_module WHERE name='base'")
-    installed_version = cr.fetchone()[0]
-    for script_path in pre_update_scripts:
-        _logger.info("Running pre-update script: %s", script_path)
-        migration.exec_script(cr, installed_version, script_path, "base", "pre")
-
-
 def _update_db(
     database,
     update_all,
@@ -293,8 +285,6 @@ def _update_db(
             )
             return
 
-        _run_pre_update_scripts(pre_update_scripts, cr)
-
         _update_db_nolock(
             conn,
             database,
@@ -303,6 +293,7 @@ def _update_db(
             watcher,
             list_only,
             ignore_addons,
+            pre_update_scripts,
         )
 
 
@@ -420,6 +411,10 @@ def OdooEnvironmentWithUpdate(database, ctx, **kwargs):
         "This is useful for performing custom pre-update tasks, before the Odoo update "
         "process starts."
         "The scripts will be executed in the order they are provided. "
+        "Note: these scripts only run if at least one addon is actually updated. "
+        "If no addon checksum changed, click-odoo-update exits early and the "
+        "scripts are not executed, even though they were provided. Use "
+        "--update-all to guarantee they always run."
     ),
 )
 def main(

--- a/click_odoo_contrib/update.py
+++ b/click_odoo_contrib/update.py
@@ -9,6 +9,7 @@ import os
 import threading
 from contextlib import closing, contextmanager
 from datetime import timedelta
+from pathlib import Path
 from time import sleep
 
 import click
@@ -260,6 +261,19 @@ def _update_db_nolock(
         _save_installed_checksums(cr, ignore_addons)
 
 
+def _run_pre_update_scripts(pre_update_scripts, cr):
+    if not pre_update_scripts:
+        return
+    from odoo.modules import migration
+
+    _logger.info("Running pre-update scripts...")
+    cr.execute("SELECT latest_version FROM ir_module_module WHERE name='base'")
+    installed_version = cr.fetchone()[0]
+    for script_path in pre_update_scripts:
+        _logger.info("Running pre-update script: %s", script_path)
+        migration.exec_script(cr, installed_version, script_path, "base", "pre")
+
+
 def _update_db(
     database,
     update_all,
@@ -268,6 +282,7 @@ def _update_db(
     list_only=False,
     ignore_addons=None,
     only_compute_hashes=False,
+    pre_update_scripts=None,
 ):
     conn = odoo.sql_db.db_connect(database)
     with conn.cursor() as cr, advisory_lock(cr, "click-odoo-update/" + database):
@@ -277,6 +292,8 @@ def _update_db(
                 "Only computed and stored module hashes, update is not performed."
             )
             return
+
+        _run_pre_update_scripts(pre_update_scripts, cr)
 
         _update_db_nolock(
             conn,
@@ -296,6 +313,17 @@ def _get_ignore_addons(ignore_addons_str=None, ignore_core_addons=None):
     if ignore_core_addons:
         ignore_addons.update(get_core_addons(OdooSeries(odoo.release.series)))
     return ignore_addons
+
+
+def _parse_pre_update_scripts(ctx, param, value):
+    if not value:
+        return []
+    if isinstance(value, (list, tuple)):
+        values = value
+    else:
+        values = [item.strip() for item in value.split(",") if item.strip()]
+    path_type = click.Path(exists=True, dir_okay=False, path_type=Path)
+    return [path_type.convert(item, param, ctx) for item in values]
 
 
 @contextmanager
@@ -323,6 +351,7 @@ def OdooEnvironmentWithUpdate(database, ctx, **kwargs):
             ctx.params["list_only"],
             ignore_addons,
             ctx.params["only_compute_hashes"],
+            ctx.params["pre_update_scripts"],
         )
     finally:
         if watcher:
@@ -383,6 +412,16 @@ def OdooEnvironmentWithUpdate(database, ctx, **kwargs):
         "and you don't want to run `click-odoo-update --update-all`."
     ),
 )
+@click.option(
+    "--pre-update-scripts",
+    callback=_parse_pre_update_scripts,
+    help=(
+        "Comma-separated list of Python scripts to run before updating the database. "
+        "This is useful for performing custom pre-update tasks, before the Odoo update "
+        "process starts."
+        "The scripts will be executed in the order they are provided. "
+    ),
+)
 def main(
     env,
     i18n_overwrite,
@@ -393,6 +432,7 @@ def main(
     ignore_addons,
     ignore_core_addons,
     only_compute_hashes,
+    pre_update_scripts,
 ):
     """Update an Odoo database (odoo -u), automatically detecting
     addons to update based on a hash of their file content, compared
@@ -414,6 +454,11 @@ def main(
             return
         else:
             raise click.ClickException(msg)
+    if pre_update_scripts:
+        _logger.info(
+            "Pre-update scripts: %s",
+            ", ".join(str(path) for path in pre_update_scripts),
+        )
     # TODO: warn if modules to upgrade ?
 
 

--- a/newsfragments/260626.feature.rst
+++ b/newsfragments/260626.feature.rst
@@ -1,0 +1,4 @@
+*click-odoo-update: New option --pre-update-scripts* This option allows users to specify a list of Python scripts that
+will be executed before the database update process begins. These scripts are similar to Odoo's pre-migration scripts
+and can be used to perform custom tasks or modifications before the update. The scripts will be executed in the order
+they are provided, and they will have access to the database cursor for executing SQL commands.

--- a/newsfragments/260626.feature.rst
+++ b/newsfragments/260626.feature.rst
@@ -2,3 +2,7 @@
 will be executed before the database update process begins. These scripts are similar to Odoo's pre-migration scripts
 and can be used to perform custom tasks or modifications before the update. The scripts will be executed in the order
 they are provided, and they will have access to the database cursor for executing SQL commands.
+
+Note: these scripts only run if at least one addon is actually updated. If no addon checksum changed since the
+last run, click-odoo-update exits early and the scripts are not executed, even though they were provided. Combine
+with ``--update-all`` to guarantee they always run.

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -63,3 +63,14 @@ def odoocfg(request, tmpdir):
         )
     )
     yield odoo_cfg
+
+
+def min_odoo_version(min_version):
+    if isinstance(min_version, str):
+        min_version_parts = tuple(int(part) for part in min_version.split("."))
+    else:
+        min_version_parts = tuple(int(part) for part in str(min_version).split("."))
+    return pytest.mark.skipif(
+        odoo.release.version_info < min_version_parts,
+        reason=f"requires Odoo >= {min_version}",
+    )

--- a/tests/test_update.py
+++ b/tests/test_update.py
@@ -234,6 +234,7 @@ def migrate(cr, version):
         _addons_path("v1"),
         "-d",
         odoodb,
+        "--update-all",
         "--pre-update-scripts",
         str(script),
     ]
@@ -259,6 +260,7 @@ def migrate(cr, version):
         _addons_path("v1"),
         "-d",
         odoodb,
+        "--update-all",
         "--pre-update-scripts",
         str(script),
     ]
@@ -279,6 +281,7 @@ def test_pre_update_scripts_missing_migrate_aborts(odoodb, tmp_path):
         _addons_path("v1"),
         "-d",
         odoodb,
+        "--update-all",
         "--pre-update-scripts",
         str(script),
     ]

--- a/tests/test_update.py
+++ b/tests/test_update.py
@@ -10,8 +10,10 @@ import pytest
 from click.testing import CliRunner
 from click_odoo import OdooEnvironment, odoo, odoo_bin
 
+from .conftest import min_odoo_version
 from click_odoo_contrib.update import (
     _load_installed_checksums,
+    _parse_pre_update_scripts,
     main,
 )
 
@@ -176,3 +178,109 @@ def test_parallel_watcher(odoodb):
     ]
     subprocess.check_call(cmd)
     # TODO Test an actual lock
+
+
+def test_pre_update_scripts_invalid_path():
+    # --pre-update-scripts with a non-existing path produces a clean error
+    runner = CliRunner()
+    result = runner.invoke(
+        main, ["--pre-update-scripts", "/nonexistent/script.py", "-d", "dummy"]
+    )
+    assert result.exit_code != 0
+    assert "nonexistent" in result.output
+    # No traceback expected — Click handles BadParameter cleanly
+    assert "Traceback" not in result.output
+
+
+def test_pre_update_scripts_valid_paths(tmp_path):
+    # _parse_pre_update_scripts accepts existing files and returns Path objects.
+    script1 = tmp_path / "pre_a.py"
+    script2 = tmp_path / "pre_b.py"
+    script1.write_text("def migrate(cr, version): pass\n")
+    script2.write_text("def migrate(cr, version): pass\n")
+
+    result = _parse_pre_update_scripts(
+        ctx=None,
+        param=None,
+        value=f"{script1},{script2}",
+    )
+    assert result == [script1, script2]
+
+
+def test_pre_update_scripts_directory_rejected(tmp_path):
+    # _parse_pre_update_scripts rejects a directory (files only)
+    import click
+
+    with pytest.raises((click.exceptions.BadParameter, SystemExit)):
+        _parse_pre_update_scripts(ctx=None, param=None, value=str(tmp_path))
+
+
+@min_odoo_version("16.0")
+def test_pre_update_scripts_executed(odoodb, tmp_path):
+    # A valid pre-update script is actually called before the Odoo update.
+    marker = tmp_path / "executed.txt"
+    script = tmp_path / "pre_script.py"
+    script.write_text(
+        f"""\
+def migrate(cr, version):
+    open({str(marker)!r}, "w").close()
+"""
+    )
+    cmd = [
+        sys.executable,
+        "-m",
+        "click_odoo_contrib.update",
+        "--addons-path",
+        _addons_path("v1"),
+        "-d",
+        odoodb,
+        "--pre-update-scripts",
+        str(script),
+    ]
+    subprocess.check_call(cmd)
+    assert marker.exists(), "pre-update script was not executed"
+
+
+@min_odoo_version("16.0")
+def test_pre_update_scripts_error_aborts_update(odoodb, tmp_path):
+    # A pre-update script that raises an exception aborts the command.
+    script = tmp_path / "pre_failing.py"
+    script.write_text(
+        """\
+def migrate(cr, version):
+    raise RuntimeError("intentional failure")
+"""
+    )
+    cmd = [
+        sys.executable,
+        "-m",
+        "click_odoo_contrib.update",
+        "--addons-path",
+        _addons_path("v1"),
+        "-d",
+        odoodb,
+        "--pre-update-scripts",
+        str(script),
+    ]
+    with pytest.raises(subprocess.CalledProcessError):
+        subprocess.check_call(cmd)
+
+
+@min_odoo_version("18.0")
+def test_pre_update_scripts_missing_migrate_aborts(odoodb, tmp_path):
+    # A script without a migrate() function aborts the command.
+    script = tmp_path / "pre_no_migrate.py"
+    script.write_text("# no migrate function\n")
+    cmd = [
+        sys.executable,
+        "-m",
+        "click_odoo_contrib.update",
+        "--addons-path",
+        _addons_path("v1"),
+        "-d",
+        odoodb,
+        "--pre-update-scripts",
+        str(script),
+    ]
+    with pytest.raises(subprocess.CalledProcessError):
+        subprocess.check_call(cmd)


### PR DESCRIPTION
…pdate scripts

This option allows users to specify a list of Python scripts that will be executed before the database update process begins. These scripts are similar to Odoo's pre-migration scripts and can be used to perform custom tasks or modifications before the update. The scripts will be executed in the order they are provided, and they will have access to the database cursor for executing SQL commands.